### PR TITLE
erlang 18 compatibility / get travis-ci working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: elixir
-elixir: 1.0.4
+elixir: 1.0.5
 notifications:
   recipients:
     - ben.wilson@cargosense.com
 otp_release:
   - 17.1
+  - 17.5
+  - 18.0
+before_script:
+  - wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -O /tmp/dynamodb_local_latest.tar.gz
+  - tar -xzf /tmp/dynamodb_local_latest.tar.gz -C /tmp
+  - java -Djava.library.path=/tmp/DynamoDBLocal_lib -jar /tmp/DynamoDBLocal.jar -inMemory &
+  - sleep 2
+addons:
+  hosts:
+    - dynamodb-local
 script: "MIX_ENV=test mix local.hex --force && MIX_ENV=test mix do deps.get, test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,25 +5,28 @@ Contributions to ExAws are absolutely appreciated. For general bug fixes or othe
 
 ## Running Tests
 Running the test suite for ex_aws requires a few things:
+
 1. DynamoDB Local must be running
   * May be downloaded from http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
   * And may be executed with `java -Djava.library.path=/DynamoDBLocal_lib -jar DynamoDBLocal.jar -inMemory`
 2. Requires two environment variables `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`
   * These must be valid AWS credentials, the minimum IAM permissions required are:
-    ```{
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "kinesis:ListStreams",
-                    "lambda:ListFunctions",
-                    "s3:ListAllMyBuckets"
-                ],
-                "Resource": "*"
-            }
-        ]
-    }```
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "kinesis:ListStreams",
+              "lambda:ListFunctions",
+              "s3:ListAllMyBuckets"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+```
 
 The test suite can be run with `AWS_ACCESS_KEY_ID=your-aws-access-key AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key mix test`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,30 @@ Contributing
 
 Contributions to ExAws are absolutely appreciated. For general bug fixes or other tweaks to existing code, a regular pull request is fine. For those who wish to add to the set of APIs supported by ExAws, please consult the rest of this document, as any PRs adding a service are expected to follow the structure defined herein.
 
+## Running Tests
+Running the test suite for ex_aws requires a few things:
+1. DynamoDB Local must be running
+  * May be downloaded from http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
+  * And may be executed with `java -Djava.library.path=/DynamoDBLocal_lib -jar DynamoDBLocal.jar -inMemory`
+2. Requires two environment variables `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`
+  * These must be valid AWS credentials, the minimum IAM permissions required are:
+    ```{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "kinesis:ListStreams",
+                    "lambda:ListFunctions",
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }```
+
+The test suite can be run with `AWS_ACCESS_KEY_ID=your-aws-access-key AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key mix test`
+
 ## Organization
 
 If you're the kind of person who learns best by example, it may help to read the Example section below first.

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ExAws.Mixfile do
       {:sweet_xml, "~> 0.2.1", only: [:test]},
       {:httpoison, "~> 0.7", only: [:test, :dev]},
       {:poison, "~> 1.2.0", only: [:test, :dev]},
-      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.1", only: :test},
+      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2", only: :test},
       {:httpotion, "~> 2.0.0", only: :test},
       {:jsx, "~> 2.5.2", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "hackney": {:hex, :hackney, "1.2.0"},
   "httpoison": {:hex, :httpoison, "0.7.0"},
   "httpotion": {:hex, :httpotion, "2.0.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "d2e369ff42666c3574b8b7ec26f69027895c4d94", [tag: "v4.1.1"]},
+  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
   "idna": {:hex, :idna, "1.0.2"},
   "jsx": {:hex, :jsx, "2.5.3"},
   "mixunit": {:hex, :mixunit, "0.9.2"},


### PR DESCRIPTION
Tests should run and pass now on travis provided you enter the aws credential environment variables in the travis UI.

Tests passed in Erlang 18.0 / 17.5 / 17.1 in travis on my account. I added 17.5 since that was the most recent 17.x release but left 17.1 since that's what you had configured previously, feel free to add / remove versions to test as you see fit.

Also added a blurb to CONTRIBUTING.md with instructions for getting tests passing locally. Note that we'll probably need to tweak the IAM example as tests are added for services in the future though.