### PR TITLE
use String.Chars for float to get a more ordinary value

### DIFF
--- a/lib/ex_aws/dynamo/encodable.ex
+++ b/lib/ex_aws/dynamo/encodable.ex
@@ -20,7 +20,7 @@ end
 
 defimpl ExAws.Dynamo.Encodable, for: Float do
   def encode(val, _) do
-    %{"N" => val |> Float.to_string}
+    %{"N" => String.Chars.Float.to_string(val)}
   end
 end
 

--- a/test/lib/ex_aws/dynamo/encoder_test.exs
+++ b/test/lib/ex_aws/dynamo/encoder_test.exs
@@ -22,7 +22,7 @@ defmodule ExAws.Dynamo.EncoderTest do
   end
 
   test "Encoder can handle floats" do
-    assert Encoder.encode(0.4) == %{"N" => "4.00000000000000022204e-01"}
+    assert Encoder.encode(0.4) == %{"N" => "0.4"}
   end
 
   test "Encoder with structs works properly" do


### PR DESCRIPTION
Fixes #85 