### PR TITLE
Implement S3 presigned_url API function

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -4,87 +4,59 @@ defmodule ExAws.Auth do
   @moduledoc false
 
   def headers(http_method, url, service, config, headers, body) do
-    now = :os.timestamp |> :calendar.now_to_universal_time
+    datetime = :calendar.universal_time
     headers = [
       {"host", URI.parse(url).host},
-      {"x-amz-date", amz_date(now)} |
+      {"x-amz-date", amz_date(datetime)} |
       headers
     ]
     |> handle_temp_credentials(config)
 
     auth_header = auth_header(
-      config[:access_key_id],
-      config[:secret_access_key],
-      http_method |> method_string,
+      http_method,
       url,
-      config[:region],
-      service |> service_name,
       headers,
       body,
-      now)
+      service |> service_name,
+      datetime,
+      config)
 
     [{"Authorization", auth_header} | headers ]
   end
 
-  def handle_temp_credentials(headers, %{security_token: token}) do
+  def presigned_url(http_method, url, service, config, expires) do
+    datetime = :calendar.universal_time
+    headers = presigned_url_headers(url)
+    query = presigned_url_query(datetime, service, config, expires)
+    url = "#{url}?#{query}"
+    signature = signature(http_method, url, headers, nil, service, datetime, config)
+    "#{url}&X-Amz-Signature=#{signature}"
+  end
+
+  defp handle_temp_credentials(headers, %{security_token: token}) do
     [{"X-Amz-Security-Token", token} | headers]
   end
-  def handle_temp_credentials(headers, _), do: headers
+  defp handle_temp_credentials(headers, _), do: headers
 
-  def auth_header(access_key, secret_key, http_method, url, region, service, headers, body, {date, _} = now) do
-    date  = date |> quasi_iso_format
-    scope = "#{date}/#{region}/#{service}/aws4_request"
-
-    signing_key = build_signing_key(secret_key, date, region, service)
-
-    signature = http_method
-    |> build_canonical_request(url, headers, body)
-    |> build_string_to_sign(now, scope)
-    |> sign_with(signing_key)
-
+  defp auth_header(http_method, url, headers, body, service, datetime, config) do
+    signature = signature(http_method, url, headers, body, service, datetime, config)
     [
-      "AWS4-HMAC-SHA256 Credential=", access_key, "/", scope, ",",
+      "AWS4-HMAC-SHA256 Credential=", credentials(datetime, service, config), ",",
       "SignedHeaders=", signed_headers(headers), ",",
       "Signature=", signature
     ] |> IO.iodata_to_binary
   end
 
-  def build_signing_key(secret_key, date, region, service) do
-    ["AWS4", secret_key]
-    |> hmac_sha256(date)
-    |> hmac_sha256(region)
-    |> hmac_sha256(service)
-    |> hmac_sha256("aws4_request")
+  defp signature(http_method, url, headers, body, datetime, service, config) do
+    request = build_canonical_request(http_method, url, headers, body)
+    string_to_sign = string_to_sign(request, datetime, service, config)
+    signing_key = signing_key(datetime, service, config)
+    hmac_sha256(signing_key, string_to_sign) |> bytes_to_hex
   end
 
-  def build_string_to_sign(canonical_request, now, scope) do
-    timestamp = now |> amz_date
-    hashed_canonical_request = hash_sha256(canonical_request)
-
-    [
-      "AWS4-HMAC-SHA256", "\n",
-      timestamp, "\n",
-      scope, "\n",
-      hashed_canonical_request
-    ] |> IO.iodata_to_binary
-  end
-
-  def sign_with(string_to_sign, signing_key) do
-    signing_key
-    |> hmac_sha256(string_to_sign)
-    |> bytes_to_hex
-  end
-
-  def signed_headers(headers) do
-    headers
-    |> Enum.map(fn({k, _}) -> String.downcase(k) end)
-    |> Enum.sort(&(&1 < &2))
-    |> Enum.join(";")
-  end
-
-  def build_canonical_request(http_method, url, headers, body) do
+  defp build_canonical_request(http_method, url, headers, body) do
     uri = URI.parse(url)
-    http_method = http_method |> String.upcase
+    http_method = http_method |> method_string |> String.upcase
 
     query_params = uri.query |> canonical_query_params
 
@@ -97,31 +69,84 @@ defmodule ExAws.Auth do
     |> Keyword.keys
     |> Enum.join(";")
 
+    payload = case body do
+                nil -> "UNSIGNED-PAYLOAD"
+                _ -> ExAws.Auth.Utils.hash_sha256(body)
+              end
+
     [
       http_method, "\n",
-      uri.path |> URI.encode(&valid_path_char?/1), "\n",
+      uri_encode(uri.path), "\n",
       query_params, "\n",
       header_string, "\n",
       "\n",
       signed_headers_list, "\n",
-      ExAws.Auth.Utils.hash_sha256(body)
+      payload
     ] |> IO.iodata_to_binary
   end
 
-  def canonical_query_params(nil), do: ""
-  def canonical_query_params(params) do
+  defp signing_key(datetime, service, config) do
+    ["AWS4", config[:secret_access_key]]
+    |> hmac_sha256(date(datetime))
+    |> hmac_sha256(config[:region])
+    |> hmac_sha256(service)
+    |> hmac_sha256("aws4_request")
+  end
+
+  defp string_to_sign(request, datetime, service, config) do
+    request = hash_sha256(request)
+
+    """
+    AWS4-HMAC-SHA256
+    #{amz_date(datetime)}
+    #{scope(datetime, service, config)}
+    #{request}
+    """
+    |> String.rstrip
+  end
+
+  defp signed_headers(headers) do
+    headers
+    |> Enum.map(fn({k, _}) -> String.downcase(k) end)
+    |> Enum.sort(&(&1 < &2))
+    |> Enum.join(";")
+  end
+
+  defp canonical_query_params(nil), do: ""
+  defp canonical_query_params(params) do
     params
     |> URI.query_decoder
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
     |> URI.encode_query
   end
 
-  def canonical_headers(headers) do
+  defp canonical_headers(headers) do
     headers
     |> Enum.map(fn
       {k, v} when is_binary(v) -> {String.downcase(k), String.strip(v)}
       {k, v} -> {String.downcase(k), v}
     end)
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
+  end
+
+  defp presigned_url_headers(url) do
+    uri = URI.parse(url)
+    "host:#{uri.host}"
+  end
+
+  defp presigned_url_query(datetime, service, config, expires) do
+    "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+    <> "X-Amz-Credential=#{uri_encode(credentials(datetime, service, config))}&"
+    <> "X-Amz-Date=#{amz_date(datetime)}&"
+    <> "X-Amz-Expires=#{expires}&"
+    <> "X-Amz-SignedHeaders=host"
+  end
+
+  defp credentials(datetime, service, config) do
+    "#{config[:access_key_id]}/#{scope(datetime, service, config)}"
+  end
+
+  defp scope(datetime, service, config) do
+    "#{date(datetime)}/#{config[:region]}/#{service}/aws4_request"
   end
 end

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -24,8 +24,7 @@ defmodule ExAws.Auth do
     [{"Authorization", auth_header} | headers ]
   end
 
-  def presigned_url(http_method, url, service, config, expires) do
-    datetime = :calendar.universal_time
+  def presigned_url(http_method, url, service, datetime, config, expires) do
     service = service_name(service)
     headers = presigned_url_headers(url)
     query = presigned_url_query(service, datetime, config, expires)
@@ -55,7 +54,7 @@ defmodule ExAws.Auth do
     hmac_sha256(signing_key, string_to_sign) |> bytes_to_hex
   end
 
-  defp build_canonical_request(http_method, url, headers, body) do
+  def build_canonical_request(http_method, url, headers, body) do
     uri = URI.parse(url)
     http_method = http_method |> method_string |> String.upcase
 
@@ -132,7 +131,7 @@ defmodule ExAws.Auth do
 
   defp presigned_url_headers(url) do
     uri = URI.parse(url)
-    "host:#{uri.host}"
+    [{"host", uri.host}]
   end
 
   defp presigned_url_query(service, datetime, config, expires) do

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -140,6 +140,10 @@ defmodule ExAws.Auth do
     <> "X-Amz-Date=#{amz_date(datetime)}&"
     <> "X-Amz-Expires=#{expires}&"
     <> "X-Amz-SignedHeaders=host"
+    <> case config[:security_token] do
+         nil -> ""
+         token -> "&X-Amz-Security-Token=#{uri_encode(token)}"
+       end
   end
 
   defp credentials(service, datetime, config) do

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -70,9 +70,9 @@ defmodule ExAws.Auth do
     |> Enum.join(";")
 
     payload = case body do
-                nil -> "UNSIGNED-PAYLOAD"
-                _ -> ExAws.Auth.Utils.hash_sha256(body)
-              end
+      nil -> "UNSIGNED-PAYLOAD"
+      _ -> ExAws.Auth.Utils.hash_sha256(body)
+    end
 
     [
       http_method, "\n",

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -1,4 +1,8 @@
 defmodule ExAws.Auth.Utils do
+  def uri_encode(url) do
+    URI.encode(url, &valid_path_char?/1)
+  end
+
   def valid_path_char?(?/), do: true
   # Space character
   def valid_path_char?(?\ ), do: false
@@ -28,6 +32,10 @@ defmodule ExAws.Auth.Utils do
     method
     |> Atom.to_string
     |> String.upcase
+  end
+
+  def date({date, _time}) do
+    date |> quasi_iso_format
   end
 
   def amz_date({date, time}) do

--- a/lib/ex_aws/s3/client.ex
+++ b/lib/ex_aws/s3/client.ex
@@ -418,12 +418,10 @@ defmodule ExAws.S3.Client do
   @doc """
   Generates a pre-signed URL for this object.
 
-  Raises an ArgumentError if `:expires_in` exceeds one week.
-
   When option param :virtual_host is `true`, the {#bucket} name will be used as
   the hostname. This will cause the returned URL to be 'http' and not 'https'.
   """
-  defcallback presigned_url(http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: binary
+  defcallback presigned_url(http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: {:ok, binary} | {:error, binary}
 
   @doc """
   Enables custom request handling.

--- a/lib/ex_aws/s3/client.ex
+++ b/lib/ex_aws/s3/client.ex
@@ -71,6 +71,11 @@ defmodule ExAws.S3.Client do
     | [aws_kms_key_id: binary]
     | customer_encryption_opts
 
+  @type presigned_url_opts :: [
+    expires_in: integer,
+    virtual_host: boolean
+  ]
+
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
 
   ## Bucket functions
@@ -409,6 +414,9 @@ defmodule ExAws.S3.Client do
   @doc "List the parts of a multipart upload"
   defcallback list_parts(bucket :: binary, object :: binary, upload_id :: binary) :: ExAws.Request.response_t
   defcallback list_parts(bucket :: binary, object :: binary, upload_id :: binary, opts :: Keyword.t) :: ExAws.Request.response_t
+
+  @doc "Generates a pre-signed URL for this object."
+  defcallback presigned_url(http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: binary
 
   @doc """
   Enables custom request handling.

--- a/lib/ex_aws/s3/client.ex
+++ b/lib/ex_aws/s3/client.ex
@@ -415,7 +415,14 @@ defmodule ExAws.S3.Client do
   defcallback list_parts(bucket :: binary, object :: binary, upload_id :: binary) :: ExAws.Request.response_t
   defcallback list_parts(bucket :: binary, object :: binary, upload_id :: binary, opts :: Keyword.t) :: ExAws.Request.response_t
 
-  @doc "Generates a pre-signed URL for this object."
+  @doc """
+  Generates a pre-signed URL for this object.
+
+  Raises an ArgumentError if `:expires_in` exceeds one week.
+
+  When option param :virtual_host is `true`, the {#bucket} name will be used as
+  the hostname. This will cause the returned URL to be 'http' and not 'https'.
+  """
   defcallback presigned_url(http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: binary
 
   @doc """

--- a/lib/ex_aws/s3/impl.ex
+++ b/lib/ex_aws/s3/impl.ex
@@ -451,7 +451,9 @@ defmodule ExAws.S3.Impl do
             true -> "#{config[:scheme]}#{bucket}.#{config[:host]}/#{object}"
             false -> "#{config[:scheme]}#{config[:host]}/#{bucket}/#{object}"
           end
-    ExAws.Auth.presigned_url(http_method, url, client.service, client.config, expires)
+    datetime = :calendar.universal_time
+    ExAws.Auth.presigned_url(
+      http_method, url, client.service, datetime, client.config, expires)
   end
 
   defp request(%{__struct__: client_module} = client, action, bucket, path, data \\ []) do

--- a/lib/ex_aws/s3/impl.ex
+++ b/lib/ex_aws/s3/impl.ex
@@ -441,6 +441,19 @@ defmodule ExAws.S3.Impl do
     |> Parsers.parse_list_parts
   end
 
+  def presigned_url(client, http_method, bucket, object, opts \\ []) do
+    expires = Keyword.get(opts, :expires_in, 3600)
+    virtual_host = Keyword.get(opts, :virtual_host, false)
+    # TODO: throw if expires > 604800
+
+    config = client.config
+    url = case virtual_host do
+            true -> "#{config[:scheme]}#{bucket}.#{config[:host]}/#{object}"
+            false -> "#{config[:scheme]}#{config[:host]}/#{bucket}/#{object}"
+          end
+    ExAws.Auth.presigned_url(http_method, url, client.service, client.config, expires)
+  end
+
   defp request(%{__struct__: client_module} = client, action, bucket, path, data \\ []) do
     client_module.request(client, action, bucket, path, data)
   end

--- a/lib/ex_aws/s3/impl.ex
+++ b/lib/ex_aws/s3/impl.ex
@@ -441,28 +441,30 @@ defmodule ExAws.S3.Impl do
     |> Parsers.parse_list_parts
   end
 
+  @one_week 60 * 60 * 24 * 7
   def presigned_url(client, http_method, bucket, object, opts \\ []) do
     expires_in = Keyword.get(opts, :expires_in, 3600)
     virtual_host = Keyword.get(opts, :virtual_host, false)
-    raise_if_exceeds_one_week(expires_in)
-    config = client.config
-    url = case virtual_host do
-            true -> "http://#{bucket}.#{config[:host]}/#{object}"
-            false -> "#{config[:scheme]}#{config[:host]}/#{bucket}/#{object}"
-          end
-    datetime = :calendar.universal_time
-    ExAws.Auth.presigned_url(
-      http_method, url, client.service, datetime, client.config, expires_in)
+    case expires_in > @one_week do
+      true -> {:error, "expires_in_exceeds_one_week"}
+      false ->
+        config = client.config
+        url = url_to_sign(bucket, object, config, virtual_host)
+        datetime = :calendar.universal_time
+        {:ok, ExAws.Auth.presigned_url(
+            http_method, url, client.service, datetime, client.config, expires_in)}
+    end
   end
 
   defp request(%{__struct__: client_module} = client, action, bucket, path, data \\ []) do
     client_module.request(client, action, bucket, path, data)
   end
 
-  defp raise_if_exceeds_one_week(expires_in) do
-    if expires_in > 60 * 60 * 24 * 7 do
-      msg = "expires_in value of #{expires_in} exceeds one-week maximum"
-      raise ArgumentError, message: msg
+  defp url_to_sign(bucket, object, config, virtual_host) do
+    object = ExAws.S3.Request.ensure_slash(object)
+    case virtual_host do
+      true -> "http://#{bucket}.#{config[:host]}#{object}"
+      false -> "#{config[:scheme]}#{config[:host]}/#{bucket}#{object}"
     end
   end
 end

--- a/lib/ex_aws/s3/request.ex
+++ b/lib/ex_aws/s3/request.ex
@@ -33,8 +33,8 @@ defmodule ExAws.S3.Request do
   def add_query(url, resource, ""),    do: url <> "?" <> resource
   def add_query(url, resource, query), do: url <> "?" <> resource <> "&" <> query
 
-  defp ensure_slash("/" <> _ = path), do: path
-  defp ensure_slash(path), do:  "/" <> path
+  def ensure_slash("/" <> _ = path), do: path
+  def ensure_slash(path), do:  "/" <> path
 
   defp host_and_bucket(host, ""), do: host
   defp host_and_bucket(host, bucket) do

--- a/test/lib/ex_aws/auth_test.exs
+++ b/test/lib/ex_aws/auth_test.exs
@@ -6,6 +6,32 @@ defmodule ExAws.AuthTest do
 
   test "build_canonical_request can handle : " do
     expected = "GET\n/bar%3Abaz%40blag\n\n\n\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    assert build_canonical_request("get", "http://foo.com/bar:baz@blag", %{}, "") == expected
+    assert build_canonical_request(:get, "http://foo.com/bar:baz@blag", %{}, "") == expected
+  end
+
+  test "presigned url" do
+    # Data taken from example in:
+    # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/test.txt"
+    service = :s3
+    datetime = {{2013, 5, 24}, {0, 0, 0}}
+    config = [access_key_id: "AKIAIOSFODNN7EXAMPLE",
+              secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+              region: "us-east-1"
+             ]
+    expires = 86400
+    actual = ExAws.Auth.presigned_url(http_method, url, service, datetime, config, expires)
+
+    expected =
+      "https://examplebucket.s3.amazonaws.com/test.txt" <>
+      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
+      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request" <>
+      "&X-Amz-Date=20130524T000000Z" <>
+      "&X-Amz-Expires=86400" <>
+      "&X-Amz-SignedHeaders=host" <>
+      "&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404"
+
+    assert expected == actual
   end
 end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -106,7 +106,7 @@ defmodule ExAws.S3Test do
 
   test "#presigned_url passing virtual_host=false option" do
     url = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: false])
-    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "100")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "3600")
   end
 
   test "#presigned_url passing virtual_host=true option" do
@@ -133,8 +133,10 @@ defmodule ExAws.S3Test do
     assert [{"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
             {"X-Amz-Credential", _},
             {"X-Amz-Date", _},
-            {"X-Amz-Expires", expected_expire},
+            {"X-Amz-Expires", _},
             {"X-Amz-SignedHeaders", "host"},
             {"X-Amz-Signature", _}] = headers
+    assert {"X-Amz-Expires", expected_expire} ==
+      List.keyfind(headers, "X-Amz-Expires", 0)
   end
 end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -95,35 +95,40 @@ defmodule ExAws.S3Test do
   end
 
   test "#presigned_url no opts" do
-    url = S3.presigned_url(:get, "bucket", "foo.txt")
+    {:ok, url} = S3.presigned_url(:get, "bucket", "foo.txt")
     assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "3600")
   end
 
   test "#presigned_url passing expires_in option" do
-    url = S3.presigned_url(:get, "bucket", "foo.txt", [expires_in: 100])
+    {:ok, url} = S3.presigned_url(:get, "bucket", "foo.txt", [expires_in: 100])
     assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "100")
   end
 
   test "#presigned_url passing virtual_host=false option" do
-    url = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: false])
+    {:ok, url} = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: false])
     assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "3600")
   end
 
   test "#presigned_url passing virtual_host=true option" do
-    url = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: true])
+    {:ok, url} = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: true])
     assert_pre_signed_url(url, "http://bucket.s3.amazonaws.com/foo.txt", "3600")
   end
 
   test "#presigned_url passing both expires_in and virtual_host options" do
     opts = [expires_in: 100, virtual_host: true]
-    url = S3.presigned_url(:get, "bucket", "foo.txt", opts)
+    {:ok, url} = S3.presigned_url(:get, "bucket", "foo.txt", opts)
     assert_pre_signed_url(url, "http://bucket.s3.amazonaws.com/foo.txt", "100")
+  end
+
+  test "#presigned_url file is path with slash" do
+    {:ok, url} = S3.presigned_url(:get, "bucket", "/foo/bar.txt")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo/bar.txt", "3600")
   end
 
   test "#presigned_url raises exception on bad expires_in option" do
     opts = [expires_in: 60 * 60 * 24 * 8]
-    assert_raise(
-      ArgumentError, fn -> S3.presigned_url(:get, "bucket", "foo.txt", opts) end)
+    {:error, reason} = S3.presigned_url(:get, "bucket", "foo.txt", opts)
+    assert "expires_in_exceeds_one_week" == reason
   end
 
   defp assert_pre_signed_url(url, expected_scheme_host_path, expected_expire) do

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -96,35 +96,39 @@ defmodule ExAws.S3Test do
 
   test "#presigned_url no opts" do
     url = S3.presigned_url(:get, "bucket", "foo.txt")
-    assert_pre_signed_url(url, "s3.amazonaws.com", "/bucket/foo.txt", "3600")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "3600")
   end
 
   test "#presigned_url passing expires_in option" do
     url = S3.presigned_url(:get, "bucket", "foo.txt", [expires_in: 100])
-    assert_pre_signed_url(url, "s3.amazonaws.com", "/bucket/foo.txt", "100")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "100")
   end
 
   test "#presigned_url passing virtual_host=false option" do
     url = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: false])
-    assert_pre_signed_url(url, "s3.amazonaws.com", "/bucket/foo.txt", "100")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo.txt", "100")
   end
 
   test "#presigned_url passing virtual_host=true option" do
     url = S3.presigned_url(:get, "bucket", "foo.txt", [virtual_host: true])
-    assert_pre_signed_url(url, "bucket.s3.amazonaws.com", "/foo.txt", "3600")
+    assert_pre_signed_url(url, "http://bucket.s3.amazonaws.com/foo.txt", "3600")
   end
 
   test "#presigned_url passing both expires_in and virtual_host options" do
     opts = [expires_in: 100, virtual_host: true]
     url = S3.presigned_url(:get, "bucket", "foo.txt", opts)
-    assert_pre_signed_url(url, "bucket.s3.amazonaws.com", "/foo.txt", "100")
+    assert_pre_signed_url(url, "http://bucket.s3.amazonaws.com/foo.txt", "100")
   end
 
-  defp assert_pre_signed_url(url, expected_host, expected_path, expected_expire) do
+  test "#presigned_url raises exception on bad expires_in option" do
+    opts = [expires_in: 60 * 60 * 24 * 8]
+    assert_raise(
+      ArgumentError, fn -> S3.presigned_url(:get, "bucket", "foo.txt", opts) end)
+  end
+
+  defp assert_pre_signed_url(url, expected_scheme_host_path, expected_expire) do
     uri = URI.parse(url)
-    assert "https" == uri.scheme
-    assert expected_host == uri.host
-    assert expected_path == uri.path
+    assert expected_scheme_host_path == "#{uri.scheme}://#{uri.host}#{uri.path}"
     headers = URI.query_decoder(uri.query) |> Enum.map(&(&1))
     assert [{"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
             {"X-Amz-Credential", _},


### PR DESCRIPTION
Hi Ben,

this is a very early phase PR (i.e. I am not done yet). I'd very much like to get some early feedback from you before I proceed.

My initial idea was to change as little as possible from the existing code, simply add on. But then I found that `auth.ex` had a lot of bits and pieces of what I needed, so I was kind of forced to refactor it to avoid duplication. I hope you are OK with this.

I have not tested this, not even manually, I just got it to a state where it compiles and looks like it could work. I will probably continue tomorrow. But I just would like to get a thumbs up or thumbs down from you in regards to what I have done so far.

I also have a question for you: I see that function `ExAws.S3.Request.url` is used to construct S3 URLs. At first I thought I could use it, but then I saw this rule about the `bucket` containing a `.` which I didn't understand. Why this rule? For the `presigned_url` function, there is a `virtual_host` flag which indicates whether I should include the `bucket` in the hostname or in the path. So for now I chose to build the URL myself until I get a better understanding of the existing function and find out if I can reuse it or not.

Thanks a lot Ben!