### PR TITLE
remove runtime dependency on Mix

### DIFF
--- a/lib/ex_aws/actions.ex
+++ b/lib/ex_aws/actions.ex
@@ -16,7 +16,7 @@ defmodule ExAws.Actions do
   defmacro __before_compile__(_) do
     quote do
       @action_map @actions |> Enum.reduce(%{}, fn({action, method}, actions) ->
-        name = action |> Atom.to_string |> Mix.Utils.camelize
+        name = action |> Atom.to_string |> ExAws.Utils.camelize
         Map.put(actions, action, {"#{@namespace}.#{name}", method})
       end)
       def __actions__, do: @action_map

--- a/lib/ex_aws/sqs/impl.ex
+++ b/lib/ex_aws/sqs/impl.ex
@@ -168,7 +168,7 @@ defmodule ExAws.SQS.Impl do
   defp format_param_key(key) do
     key
     |> Atom.to_string
-    |> Mix.Utils.camelize
+    |> ExAws.Utils.camelize
   end
 
   defp format_queue_attributes(:all), do: format_queue_attributes([:all])

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -17,7 +17,7 @@ defmodule ExAws.Utils do
       end
     end)
   end
-  
+
   def camelize_keys([%{} | _] = opts, deep: deep) do
     Enum.map(opts, &camelize_keys(&1, deep: deep))
   end
@@ -35,12 +35,33 @@ defmodule ExAws.Utils do
   defp camelize_key(key) when is_atom(key) do
     key
     |> Atom.to_string
-    |> Mix.Utils.camelize
+    |> camelize
   end
 
   defp camelize_key(key) when is_binary(key) do
-    key |> Mix.Utils.camelize
+    key |> camelize
   end
+
+  def camelize(string)
+  def camelize(""), do: ""
+  def camelize(<<?_, t :: binary>>), do: camelize(t)
+  def camelize(<<h, t :: binary>>),  do: <<to_upper_char(h)>> <> do_camelize(t)
+
+  defp do_camelize(<<?_, ?_, t :: binary>>),
+    do: do_camelize(<< ?_, t :: binary >>)
+  defp do_camelize(<<?_, h, t :: binary>>) when h in ?a..?z,
+    do: <<to_upper_char(h)>> <> do_camelize(t)
+  defp do_camelize(<<?_>>),
+    do: <<>>
+  defp do_camelize(<<?/, t :: binary>>),
+    do: <<?.>> <> camelize(t)
+  defp do_camelize(<<h, t :: binary>>),
+    do: <<h>> <> do_camelize(t)
+  defp do_camelize(<<>>),
+    do: <<>>
+
+  defp to_upper_char(char) when char in ?a..?z, do: char - 32
+  defp to_upper_char(char), do: char
 
   def upcase(value) when is_atom(value) do
     value


### PR DESCRIPTION
I was playing with exrm releases earlier today and noticed that my app was blowing up when I tested a release locally because Mix.Utils.camelize was undefined. I asked about it in irc and tristan__ & scrogson let me know that ExAws shouldn't be using be using mix functions at runtime. The issue could be resolved by adding :mix to my applications so it would get bundled in the release but the consensus seemed to be that mix is a build tool and shouldn't need to be bundled at runtime.

I've ported the Mix.Utils.camelize function to ExAws.Utils to remove the need for mix at runtime.