### PR TITLE
Allow specifying a port for SQS

### DIFF
--- a/lib/ex_aws/sqs/request.ex
+++ b/lib/ex_aws/sqs/request.ex
@@ -14,13 +14,17 @@ defmodule ExAws.SQS.Request do
     ExAws.Request.request(:post, url(client.config, queue_name), query, headers, client)
   end
 
-  def url(%{scheme: scheme, host: host}, queue_name) do
+  def url(%{scheme: scheme, host: host, port: port}, queue_name) do
     [
       scheme,
       host,
+      port |> port(),
       queue_name |> with_slash
     ] |> IO.iodata_to_binary
   end
+
+  defp port(80), do: ""
+  defp port(p),  do: ":#{p}"
 
   def with_slash(""), do: "/"
   def with_slash(queue), do: ["/", queue]

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,8 @@ defmodule ExAws.Mixfile do
       sqs: [
         scheme: "https://",
         host: {"$region", "sqs.$region.amazonaws.com"},
-        region: "us-east-1"
+        region: "us-east-1",
+        port: 80
       ]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "hackney": {:hex, :hackney, "1.2.0"},
   "httpoison": {:hex, :httpoison, "0.7.0"},
   "httpotion": {:hex, :httpotion, "2.0.0"},
-  "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
+  "ibrowse": {:git, "https://github.com/cmullaparthi/ibrowse.git", "ea3305d21f37eced4fac290f64b068e56df7de80", [tag: "v4.1.2"]},
   "idna": {:hex, :idna, "1.0.2"},
   "jsx": {:hex, :jsx, "2.5.3"},
   "mixunit": {:hex, :mixunit, "0.9.2"},


### PR DESCRIPTION
Useful for using tools like https://github.com/iain/fake_sqs for the dev environment, just duplicated what you did for the dynamodb request.ex

The mix.lock change happened when I ran mix deps.get on a fresh clone of ex_aws ¯\\\_(ツ)_/¯