### PR TITLE
Use percent encoding for canonical query strings, per AWS docs

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -114,6 +114,8 @@ defmodule ExAws.Auth do
     |> URI.query_decoder
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
     |> URI.encode_query
+    |> String.replace("+", "%20")
+    |> String.replace("%7E", "~")
   end
 
   def canonical_headers(headers) do

--- a/lib/ex_aws/sns/request.ex
+++ b/lib/ex_aws/sns/request.ex
@@ -8,6 +8,8 @@ defmodule ExAws.SNS.Request do
     query = params
     |> Map.put("Action", Mix.Utils.camelize(Atom.to_string(action)))
     |> URI.encode_query
+    |> String.replace("+", "%20")
+    |> String.replace("%7E", "~")
 
     headers = [
       {"x-amz-content-sha256", @empty_body_hash}


### PR DESCRIPTION
SNS publish was failing when there were spaces in the JSON as they were being incorrectly encoded as `+` instead of `%20`. Also, tilde should not be encoded.