### PR TITLE
Don't force http scheme when using virtual host

### DIFF
--- a/lib/ex_aws/s3/impl.ex
+++ b/lib/ex_aws/s3/impl.ex
@@ -463,7 +463,7 @@ defmodule ExAws.S3.Impl do
   defp url_to_sign(bucket, object, config, virtual_host) do
     object = ExAws.S3.Request.ensure_slash(object)
     case virtual_host do
-      true -> "http://#{bucket}.#{config[:host]}#{object}"
+      true -> "#{config[:scheme]}#{bucket}.#{config[:host]}#{object}"
       false -> "#{config[:scheme]}#{config[:host]}/#{bucket}#{object}"
     end
   end


### PR DESCRIPTION
ExAws must not force the `http` scheme for S3 urls when using `virtual_host: true`.

AWS fully supports serving objects via HTTPS with virtual hosts.

In fact, some regions (notably Oregon) **require** the virtual_host format if you attempt to use the path-based format. So ExAws currently cannot produce a valid https url for Oregon buckets at all.

Example of a bucket object which requires virtual host: https://s3.amazonaws.com/dev-sched-oregon/arctest/uploads/image.png

The only caveat (which I assume this logic was trying to fix initially) is if you create a bucket which is **not** DNS compliant.  However, this is thoroughly documented throughout AWS's documentation.

> When using virtual hosted–style buckets with SSL, the SSL wild card certificate only matches buckets that do not contain periods. To work around this, use HTTP or write your own certificate verification logic.