### PR TITLE
Add AWS MachineLearning#Predict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ erl_crash.dump
 /mnesia/test
 /mnesia/prod
 *.pem
+.envrc

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,3 +25,9 @@ config :ex_aws, :s3,
   scheme: "https://",
   host: "s3.amazonaws.com",
   region: "us-east-1"
+
+config :ex_aws, :machinelearning,
+  scheme: "https://",
+  host: "realtime.machinelearning.us-east-1.amazonaws.com",
+  region: "us-east-1"
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,5 +29,6 @@ config :ex_aws, :s3,
 config :ex_aws, :machinelearning,
   scheme: "https://",
   host: "realtime.machinelearning.us-east-1.amazonaws.com",
-  region: "us-east-1"
+  region: "us-east-1",
+  model_id: "ml-Ry8sJUCy97V"
 

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -1,4 +1,8 @@
 defmodule ExAws.Auth.Utils do
+  def uri_encode(nil) do
+    "/"
+  end
+
   def uri_encode(url) do
     URI.encode(url, &valid_path_char?/1)
   end

--- a/lib/ex_aws/machine_learning.ex
+++ b/lib/ex_aws/machine_learning.ex
@@ -1,0 +1,5 @@
+defmodule ExAws.MachineLearning do
+  use ExAws.MachineLearning.Client
+
+  def config_root, do: Application.get_all_env(:ex_aws)
+end

--- a/lib/ex_aws/machine_learning/client.ex
+++ b/lib/ex_aws/machine_learning/client.ex
@@ -1,0 +1,72 @@
+defmodule ExAws.MachineLearning.Client do
+  use Behaviour
+  alias ExAws.MachineLearning.Request
+
+  @moduledoc """
+  The purpose of this module is to surface the ExAws.MachineLearning API with a single
+  configuration chosen, such that it does not need passed in with every request.
+
+  Usage:
+  ```
+  defmodule MyApp.MachineLearning do
+    use ExAws.MachineLearning.Client, otp_app: :my_otp_app
+  end
+  ```
+
+  In your config
+  ```
+  config :my_otp_app, :ex_aws,
+    machinelearning: [], # machinelearning config goes here
+  ```
+
+  You can now use MyApp.MachineLearning as the module for the MachineLearning api without needing
+  to pass in a particular configuration.
+  This enables different otp apps to configure their AWS configuration separately.
+
+  The alignment with a particular OTP app however is entirely optional.
+  The following also works:
+
+  ```
+  defmodule MyApp.MachineLearning do
+    use ExAws.MachineLearning.Client
+
+    def config_root do
+      Application.get_all_env(:my_aws_config_root)
+    end
+  end
+  ```
+  ExAws now expects the config for that machinelearning client to live under
+
+  ```elixir
+  config :my_aws_config_root
+    machinelearning: [] # MachineLearning config goes here
+  ```
+
+  Default config values can be found in ExAws.Config
+
+  http://docs.aws.amazon.com/kinesis/latest/APIReference/API_Operations.html
+  """
+
+  @doc "Request a prediction from a Machine Learning Real-Time Endpoint"
+  defcallback predict(modelId :: binary, record :: %{}) :: ExAws.Request.response_t
+
+  defmacro __using__(opts) do
+    boilerplate = __MODULE__
+    |> ExAws.Client.generate_boilerplate(opts)
+
+    quote do
+      defstruct config: nil, service: :machinelearning
+      unquote(boilerplate)
+
+      @doc false
+      def request(client, action, data, headers \\ []) do
+        ExAws.MachineLearning.Request.request(client, action, data, headers)
+      end
+
+      @doc false
+      def service, do: :machinelearning
+
+      defoverridable config_root: 0, request: 4
+    end
+  end
+end

--- a/lib/ex_aws/machine_learning/client.ex
+++ b/lib/ex_aws/machine_learning/client.ex
@@ -48,7 +48,7 @@ defmodule ExAws.MachineLearning.Client do
   """
 
   @doc "Request a prediction from a Machine Learning Real-Time Endpoint"
-  defcallback predict(modelId :: binary, record :: %{}) :: ExAws.Request.response_t
+  defcallback predict(record :: %{}) :: ExAws.Request.response_t
 
   defmacro __using__(opts) do
     boilerplate = __MODULE__

--- a/lib/ex_aws/machine_learning/impl.ex
+++ b/lib/ex_aws/machine_learning/impl.ex
@@ -1,0 +1,28 @@
+defmodule ExAws.MachineLearning.Impl do
+  use ExAws.Actions
+  import ExAws.Utils, only: [camelize_keys: 1, upcase: 1]
+
+  @moduledoc false
+  # Implementation of the AWS Machine Learning API.
+  # Only Predict for now.
+  #
+  # See ExAws.MachineLearning.Client for usage.
+
+  @namespace "AmazonML_20141212"
+  @actions [
+    predict: :post,
+  ]
+
+  def predict(client, modelId, record \\ %{}) do
+    data = %{
+      "MLModelId" => modelId,
+      "Record" => record,
+    }
+
+    request(client, :predict, data)
+  end
+
+  defp request(%{__struct__: client_module} = client, action, data, headers \\ []) do
+    client_module.request(client, action, data, headers)
+  end
+end

--- a/lib/ex_aws/machine_learning/impl.ex
+++ b/lib/ex_aws/machine_learning/impl.ex
@@ -13,12 +13,8 @@ defmodule ExAws.MachineLearning.Impl do
     predict: :post,
   ]
 
-  def predict(client, modelId, record \\ %{}) do
-    data = %{
-      "MLModelId" => modelId,
-      "Record" => record,
-    }
-
+  def predict(client, record \\ %{}) do
+    data = %{ "Record" => record }
     request(client, :predict, data)
   end
 

--- a/lib/ex_aws/machine_learning/request.ex
+++ b/lib/ex_aws/machine_learning/request.ex
@@ -1,0 +1,28 @@
+defmodule ExAws.MachineLearning.Request do
+  @moduledoc false
+  # MachineLearning specific request logic.
+
+  def request(client, action, data, headers \\ []) do
+    {operation, http_method} = ExAws.MachineLearning.Impl |> ExAws.Actions.get(action)
+    headers = [
+      {"x-amz-target", operation},
+      {"content-type", "application/x-amz-json-1.1"}
+    ]
+
+    predict_endpoint = client.config |> url
+    data = Map.put(data, "PredictEndpoint", predict_endpoint)
+
+    ExAws.Request.request(http_method, predict_endpoint, data, headers, client)
+    |> parse(client.config)
+  end
+
+  def parse({:error, result}, _), do: {:error, result}
+  def parse({:ok, %{body: body}}, config) do
+    {:ok, config[:json_codec].decode!(body)}
+  end
+
+  defp url(%{scheme: scheme, host: host}) do
+    [scheme, host, "/"]
+    |> IO.iodata_to_binary
+  end
+end

--- a/lib/ex_aws/machine_learning/request.ex
+++ b/lib/ex_aws/machine_learning/request.ex
@@ -10,10 +10,12 @@ defmodule ExAws.MachineLearning.Request do
     ]
 
     predict_endpoint = client.config |> url
-    data = Map.put(data, "PredictEndpoint", predict_endpoint)
+    data = data
+    |> Map.put("PredictEndpoint", predict_endpoint)
+    |> Map.put("MLModelId", client.config[:model_id])
 
-    ExAws.Request.request(http_method, predict_endpoint, data, headers, client)
-    |> parse(client.config)
+    request = ExAws.Request.request(http_method, predict_endpoint, data, headers, client)
+    request |> parse(client.config)
   end
 
   def parse({:error, result}, _), do: {:error, result}

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExAws.Mixfile do
      version: "0.4.13",
      elixir: "~> 1.0",
      elixirc_paths: elixirc_paths(Mix.env),
-     description: "AWS client. Currently supports Dynamo, Kinesis, Lambda, S3, SQS",
+     description: "AWS client. Currently supports Dynamo, Kinesis, Lambda, S3, SQS, MachineLearning (predict)",
      name: "ExAws",
      source_url: "https://github.com/cargosense/ex_aws",
      package: package,

--- a/test/lib/ex_aws/machine_learning/integration_test.exs
+++ b/test/lib/ex_aws/machine_learning/integration_test.exs
@@ -1,0 +1,11 @@
+defmodule ExAws.MachineLearningIntegrationTest do
+  use ExUnit.Case, async: true
+
+  test "#predict" do
+    modelId = "ml-Ry8sJUCy97V"
+    record = %{"Text": "What is going on"}
+
+    assert {:ok, %{"Prediction" => prediction}} = ExAws.MachineLearning.predict(modelId, record)
+    assert Map.has_key?(prediction, "predictedLabel")
+  end
+end

--- a/test/lib/ex_aws/machine_learning/integration_test.exs
+++ b/test/lib/ex_aws/machine_learning/integration_test.exs
@@ -2,10 +2,9 @@ defmodule ExAws.MachineLearningIntegrationTest do
   use ExUnit.Case, async: true
 
   test "#predict" do
-    modelId = "ml-Ry8sJUCy97V"
     record = %{"Text": "What is going on"}
 
-    assert {:ok, %{"Prediction" => prediction}} = ExAws.MachineLearning.predict(modelId, record)
+    assert {:ok, %{"Prediction" => prediction}} = ExAws.MachineLearning.predict(record)
     assert Map.has_key?(prediction, "predictedLabel")
   end
 end

--- a/test/lib/ex_aws/machine_learning_test.exs
+++ b/test/lib/ex_aws/machine_learning_test.exs
@@ -1,0 +1,23 @@
+defmodule Test.Dummy.MachineLearning do
+  use ExAws.MachineLearning.Client
+
+  def config_root, do: Application.get_all_env(:ex_aws)
+
+  def request(_client, _action, data, headers), do: data
+end
+
+defmodule ExAws.MachineLearningTest do
+  use ExUnit.Case, async: true
+  alias Test.Dummy.MachineLearning
+
+  ## NOTE:
+  # These tests are not intended to be operational examples, but instead merely
+  # ensure that the form of the data to be sent to AWS is correct.
+  #
+
+  test "#predict" do
+    record = %{"Text": "everyday I spend my time drinking wine"}
+    assert MachineLearning.predict(record) ==
+      %{"Record" => %{Text: "everyday I spend my time drinking wine"}}
+  end
+end


### PR DESCRIPTION
Interacts with AWS to retrieve a real-time prediction from a previously created ML Model as described here:

http://docs.aws.amazon.com/machine-learning/latest/APIReference/API_Predict.html

Implementation includes two tests:
1. An integration test that expects a Record with "Text" to return a predictedLabel (Categorical target).
2. A stubbed test that ensures the Record map sent is accurate.

Any feedback is appreciated!