### PR TITLE
S3: Added parsing for CommonPrefixes when listing objects

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -23,6 +23,10 @@ if Code.ensure_loaded?(SweetXml) do
             id: ~x"./ID/text()",
             display_name: ~x"./DisplayName/text()"
           ]
+        ],
+        common_prefixes: [
+          ~x"./CommonPrefixes"l,
+          prefix: ~x"./Prefix/text()"
         ]
       )
       |> list_objects_binaries
@@ -35,6 +39,7 @@ if Code.ensure_loaded?(SweetXml) do
       Enum.into(result, %{}, fn
         {:contents, contents} -> {:contents, Enum.map(contents, &list_objects_binaries/1)}
         {:owner, v} -> {:owner, list_objects_binaries(v)}
+        {:common_prefixes, prefixes} -> {:common_prefixes, Enum.map(prefixes, &list_objects_binaries/1)}
         {k, nil} -> {k, nil}
         {k, v} -> {k, IO.chardata_to_string(v)}
       end)

--- a/test/lib/ex_aws/s3/parser_test.exs
+++ b/test/lib/ex_aws/s3/parser_test.exs
@@ -1,0 +1,36 @@
+defmodule ExAws.S3.ParserTest do
+  use ExUnit.Case, async: true
+
+  test "#parse_list_objects parses CommonPrefixes" do
+    list_objects_response = """
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <Name>example-bucket</Name>
+      <Prefix></Prefix>
+      <Marker></Marker>
+      <MaxKeys>1000</MaxKeys>
+      <Delimiter>/</Delimiter>
+      <IsTruncated>false</IsTruncated>
+      <Contents>
+        <Key>sample.jpg</Key>
+        <LastModified>2011-02-26T01:56:20.000Z</LastModified>
+        <ETag>&quot;bf1d737a4d46a19f3bced6905cc8b902&quot;</ETag>
+        <Size>142863</Size>
+        <Owner>
+        <ID>canonical-user-id</ID>
+        <DisplayName>display-name</DisplayName>
+        </Owner>
+        <StorageClass>STANDARD</StorageClass>
+      </Contents>
+      <CommonPrefixes>
+        <Prefix>photos/</Prefix>
+      </CommonPrefixes>
+    </ListBucketResult>
+    """
+
+    result = ExAws.S3.Parsers.parse_list_objects({:ok, %{body: list_objects_response}})
+    {:ok, %{body: %{common_prefixes: prefixes}}} = result
+    prefix_list = Enum.map(prefixes, &(Map.get(&1, :prefix)))
+
+    assert ["photos/"] == prefix_list
+  end
+end


### PR DESCRIPTION
This PR extends the S3 parser to include CommonPrefixes when listing objects

Thanks!