### PR TITLE
Fixes ExAws.Request.HTTPotion.request/4

### DIFF
--- a/lib/ex_aws/request/httpotion.ex
+++ b/lib/ex_aws/request/httpotion.ex
@@ -3,7 +3,7 @@ defmodule ExAws.Request.HTTPotion do
 
   @moduledoc false
 
-  def request(method, url, body, headers) do
+  def request(method, url, body \\ "", headers \\ []) do
     {:ok, HTTPotion.request(method, url, [body: body, headers: headers, ibrowse: [headers_as_is: true]])}
   end
 end


### PR DESCRIPTION
The last two args in ExAws.Request.HTTPotion.request/4 should be optional as per the HTTPoison adapter.