### PR TITLE
switch relative path when host doesn't include 's3.' in url 

### DIFF
--- a/lib/ex_aws/s3/request.ex
+++ b/lib/ex_aws/s3/request.ex
@@ -40,7 +40,11 @@ defmodule ExAws.S3.Request do
   defp host_and_bucket(host, bucket) do
     case bucket |> String.contains?(".") do
       true  -> [host, "/", bucket]
-      false -> [bucket, ".", host]
+      false ->
+        case host |> String.contains?("s3") do
+          true  -> [bucket, ".", host]
+          false -> [host, "/", bucket]
+        end
     end
   end
 end


### PR DESCRIPTION
I want to use below library on my local for development.

* https://github.com/jamhall/s3rver