### PR TITLE
Refactor client for per-request region selection

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,6 @@ config :ex_aws,
 
 config :ex_aws, :kinesis,
   scheme: "https://",
-  host: "kinesis.us-east-1.amazonaws.com",
   region: "us-east-1",
   port: 80
 
@@ -16,12 +15,10 @@ config :ex_aws, :dynamodb,
   region: "us-east-1"
 
 config :ex_aws, :lambda,
-  host: "lambda.us-east-1.amazonaws.com",
   scheme: "https://",
   region: "us-east-1",
   port: 80
 
 config :ex_aws, :s3,
   scheme: "https://",
-  host: "s3.amazonaws.com",
   region: "us-east-1"

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -16,7 +16,6 @@ defmodule ExAws.Config do
 
     %{client | config: config}
     |> retrieve_runtime_config
-    |> parse_host_for_region
   end
 
   def get(%{__struct__: client_module, service: service}) do

--- a/lib/ex_aws/dynamo/request.ex
+++ b/lib/ex_aws/dynamo/request.ex
@@ -1,9 +1,13 @@
 defmodule ExAws.Dynamo.Request do
+  alias ExAws.Config
   @moduledoc false
 
   @type response_t :: %{} | ExAws.Request.error_t
 
   def request(client, action, data) do
+    client = client
+    |> Config.parse_host_for_region
+
     {operation, http_method} = ExAws.Dynamo.Impl |> ExAws.Actions.get(action)
     headers = [
       {"x-amz-target", operation},

--- a/lib/ex_aws/kinesis/request.ex
+++ b/lib/ex_aws/kinesis/request.ex
@@ -1,10 +1,14 @@
 defmodule ExAws.Kinesis.Request do
+  alias ExAws.Config
   @moduledoc false
   # Kinesis specific request logic.
 
   @type response_t :: %{} | ExAws.Request.error_t
 
   def request(client, action, data) do
+    client = client
+    |> Config.parse_host_for_region
+
     {operation, http_method} = ExAws.Kinesis.Impl |> ExAws.Actions.get(action)
     headers = [
       {"x-amz-target", operation},

--- a/lib/ex_aws/lambda/request.ex
+++ b/lib/ex_aws/lambda/request.ex
@@ -1,10 +1,14 @@
 defmodule ExAws.Lambda.Request do
+  alias ExAws.Config
   @moduledoc false
   # Lambda specific request logic.
 
   @type response_t :: %{} | ExAws.Request.error_t
 
   def request(client, action, path, data, params \\ [], headers \\ []) do
+    client = client
+    |> Config.parse_host_for_region
+
     {_, http_method} = ExAws.Lambda.Impl |> ExAws.Actions.get(action)
     path = [path, params |> URI.encode_query] |> IO.iodata_to_binary
 

--- a/lib/ex_aws/s3/client.ex
+++ b/lib/ex_aws/s3/client.ex
@@ -76,6 +76,10 @@ defmodule ExAws.S3.Client do
     virtual_host: boolean
   ]
 
+  @type client_opts:: [
+    {:region, binary}
+  ]
+
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
 
   ## Bucket functions
@@ -112,7 +116,8 @@ defmodule ExAws.S3.Client do
     {:encoding_type, binary} |
     {:marker, binary} |
     {:max_keys, 0..1000} |
-    {:prefix, binary}
+    {:prefix, binary} |
+    {:client, client_opts}
   ]
   @doc "List objects in bucket"
   defcallback list_objects(bucket :: binary) :: ExAws.Request.response_t
@@ -258,6 +263,7 @@ defmodule ExAws.S3.Client do
     | {:if_unmodified_since, binary}
     | {:if_match, binary}
     | {:if_none_match, binary}
+    | {:client, client_opts}
   ]
 
   @doc "Determine of an object exists"
@@ -296,6 +302,7 @@ defmodule ExAws.S3.Client do
     | {:website_redirect_location, binary}
     | {:encryption, encryption_opts}
     | {:meta, amz_meta_opts}
+    | {:client, client_opts}
     | acl_opts
   ]
   @doc "Create an object within a bucket"
@@ -331,6 +338,7 @@ defmodule ExAws.S3.Client do
     | {:storage_class, :standard | :redunced_redundancy}
     | {:website_redirect_location, binary}
     | {:meta, amz_meta_opts}
+    | {:client, client_opts}
     | acl_opts
   ]
 

--- a/lib/ex_aws/s3/impl.ex
+++ b/lib/ex_aws/s3/impl.ex
@@ -1,6 +1,7 @@
 defmodule ExAws.S3.Impl do
   import ExAws.S3.Utils
   alias ExAws.S3.Parsers
+  alias ExAws.Config
 
   @moduledoc false
   # Implementation of the AWS S3 API.
@@ -14,6 +15,13 @@ defmodule ExAws.S3.Impl do
   defdelegate stream_objects!(client, bucket, opts), to: ExAws.S3.Lazy
 
   def list_buckets(client, opts \\ []) do
+    client = opts
+    |> Keyword.get(:client, [])
+    |> apply_client_options(client)
+
+    opts = opts
+    |> Keyword.delete(:client)
+
     request(client, :get, "", "/", params: opts)
   end
 
@@ -47,8 +55,13 @@ defmodule ExAws.S3.Impl do
 
   @params [:delimiter, :marker, :prefix, :encoding_type, :max_keys]
   def list_objects(client, bucket, opts \\ []) do
+    client = opts
+    |> Keyword.get(:client, [])
+    |> apply_client_options(client)
+
     params = opts
     |> format_and_take(@params)
+
     request(client, :get, bucket, "/", params: params)
     |> Parsers.parse_list_objects
   end
@@ -121,6 +134,10 @@ defmodule ExAws.S3.Impl do
   end
 
   def put_bucket(client, bucket, region, opts \\ []) do
+    client = opts
+    |> Keyword.get(:client, [])
+    |> apply_client_options(client)
+
     headers = opts
     |> Enum.into(%{})
     |> format_acl_headers
@@ -198,6 +215,10 @@ defmodule ExAws.S3.Impl do
   ###########
 
   def delete_object(client, bucket, object, opts \\ []) do
+    client = opts
+    |> Keyword.get(:client, [])
+    |> apply_client_options(client)
+
     request(client, :delete, bucket, object, headers: opts |> Enum.into(%{}))
   end
   def delete_object!(client, bucket, object, opts \\ []) do
@@ -235,6 +256,10 @@ defmodule ExAws.S3.Impl do
   def get_object(client, bucket, object, opts \\ []) do
     opts = opts |> Enum.into(%{})
 
+    client = opts
+    |> Map.get(:client, [])
+    |> apply_client_options(client)
+
     response_opts = opts
     |> Map.get(:response, %{})
     |> format_and_take(@response_params)
@@ -267,6 +292,10 @@ defmodule ExAws.S3.Impl do
   @request_headers [:range, :if_modified_since, :if_unmodified_since, :if_match, :if_none_match]
   def head_object(client, bucket, object, opts \\ []) do
     opts = opts |> Enum.into(%{})
+
+    client = opts
+    |> Map.get(:client, [])
+    |> apply_client_options(client)
 
     headers = opts
     |> format_and_take(@request_headers)
@@ -335,6 +364,10 @@ defmodule ExAws.S3.Impl do
     website_redirect_location)a
   def put_object_copy(client, dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
     opts = opts |> Enum.into(%{})
+
+    client = opts
+    |> Map.get(:client, [])
+    |> apply_client_options(client)
 
     amz_headers = opts
     |> format_and_take(@amz_headers)
@@ -450,7 +483,7 @@ defmodule ExAws.S3.Impl do
     case expires_in > @one_week do
       true -> {:error, "expires_in_exceeds_one_week"}
       false ->
-        config = client.config
+        config = Config.parse_host_for_region(client).config
         url = url_to_sign(bucket, object, config, virtual_host)
         datetime = :calendar.universal_time
         {:ok, ExAws.Auth.presigned_url(

--- a/lib/ex_aws/s3/request.ex
+++ b/lib/ex_aws/s3/request.ex
@@ -1,4 +1,5 @@
 defmodule ExAws.S3.Request do
+  alias ExAws.Config
   @moduledoc false
   # S3 specific request logic.
 
@@ -8,6 +9,8 @@ defmodule ExAws.S3.Request do
     query    = data |> Keyword.get(:params, %{}) |> URI.encode_query
     headers  = data |> Keyword.get(:headers, %{})
 
+    client = client
+    |> Config.parse_host_for_region
 
     url = client.config
     |> url(bucket, path)

--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -60,6 +60,23 @@ defmodule ExAws.S3.Utils do
     |> format_and_take(param_list)
   end
 
+  def apply_client_options([], client), do: client
+  def apply_client_options(opts, %{config: config} = client) do
+    config = opts
+    |> Enum.into(%{})
+    |> set_client_region(config)
+
+    Map.put(client, :config, config)
+  end
+
+  defp set_client_region(opts, %{host: host} = config) when is_binary(host), do: config
+  defp set_client_region(opts, config) do
+    case Map.get(opts, :region) do
+      nil -> config
+      new_region -> Map.put(config, :region, new_region)
+    end
+  end
+
   @acl_headers [:acl, :grant_read, :grant_write, :grant_read_acp, :grant_write_acp, :grant_full_control]
   def format_acl_headers(%{acl: canned_acl}) do
     %{"x-amz-acl" => normalize_param(canned_acl)}

--- a/lib/ex_aws/sqs/request.ex
+++ b/lib/ex_aws/sqs/request.ex
@@ -1,7 +1,10 @@
 defmodule ExAws.SQS.Request do
+  alias ExAws.Config
   @moduledoc false
 
   def request(client, queue_name, action, params = %{}) do
+    client = client
+    |> Config.parse_host_for_region
 
     query = params
     |> Map.put("Action", action)

--- a/test/lib/ex_aws/s3/integration_test.exs
+++ b/test/lib/ex_aws/s3/integration_test.exs
@@ -6,4 +6,9 @@ defmodule ExAws.S3IntegrationTest do
     assert body |> String.contains?("ListAllMyBucketsResult")
   end
 
+  test "#list_buckets in ap-southeast-1 region" do
+    assert {:ok, %{body: body}} = ExAws.S3.list_buckets client: [region: "ap-southeast-1"]
+    assert body |> String.contains?("ListAllMyBucketsResult")
+  end
+
 end


### PR DESCRIPTION
- Clients no longer resolve host at construction
- Clients now resolve host at each request
- S3 functions with options now have support cient: options
- The only implemented client: option is {region: binary}, selecting the
  region