### PR TITLE
add :awscli option for config values

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule ExAws.Mixfile do
       {:poison, "~> 1.2", optional: true},
       {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.2", optional: true},
       {:httpotion, "~> 2.0", optional: true},
-      {:jsx, "~> 2.5", optional: true}
+      {:jsx, "~> 2.5", optional: true},
+      {:configparser_ex, "~> 0.2", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.1.17"},
+%{"configparser_ex": {:hex, :configparser_ex, "0.2.1"},
+  "earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "hackney": {:hex, :hackney, "1.2.0"},
   "httpoison": {:hex, :httpoison, "0.7.0"},


### PR DESCRIPTION
# What is this?
This adds :awscli option for config values, this will use ConfigParser
to try and read the config files used by the awscli (Python) app. It
supports loading values from the `default` or named profiles.

# Notes
This is my 1st pass for Issue #132. I would like to make this a bit more testable, moving usage of ConfigParser to load from config similar to `json_codec`. But right now the `File.exists?` would still make testing a bit harder. But without it `ConfigParser.parse_file` would raise an error if the file doesn't exist.

