### PR TITLE
Allow ExAws.S3.Client.list_objects to handle unowned objects

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -38,9 +38,9 @@ if Code.ensure_loaded?(SweetXml) do
     defp list_objects_binaries(result) do
       Enum.into(result, %{}, fn
         {:contents, contents} -> {:contents, Enum.map(contents, &list_objects_binaries/1)}
+        {k, nil} -> {k, nil}
         {:owner, v} -> {:owner, list_objects_binaries(v)}
         {:common_prefixes, prefixes} -> {:common_prefixes, Enum.map(prefixes, &list_objects_binaries/1)}
-        {k, nil} -> {k, nil}
         {k, v} -> {k, IO.chardata_to_string(v)}
       end)
     end

--- a/test/lib/ex_aws/s3/parser_test.exs
+++ b/test/lib/ex_aws/s3/parser_test.exs
@@ -34,6 +34,32 @@ defmodule ExAws.S3.ParserTest do
     assert ["photos/"] == prefix_list
   end
 
+  test "#parse_list_objects allows unowned objects" do
+    list_objects_response = """
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+      <Name>example-bucket</Name>
+      <Prefix></Prefix>
+      <Marker></Marker>
+      <MaxKeys>1000</MaxKeys>
+      <Delimiter>/</Delimiter>
+      <IsTruncated>false</IsTruncated>
+      <Contents>
+        <Key>sample.jpg</Key>
+        <LastModified>2011-02-26T01:56:20.000Z</LastModified>
+        <ETag>&quot;bf1d737a4d46a19f3bced6905cc8b902&quot;</ETag>
+        <Size>142863</Size>
+        <StorageClass>STANDARD</StorageClass>
+      </Contents>
+      <CommonPrefixes>
+        <Prefix>photos/</Prefix>
+      </CommonPrefixes>
+    </ListBucketResult>
+    """
+
+    result = ExAws.S3.Parsers.parse_list_objects({:ok, %{body: list_objects_response}})
+    {:ok, _} = result
+  end
+
 
   test "#initiate_multipart_upload parses response" do
     initiate_multipart_upload_response = """


### PR DESCRIPTION
Hi! Thanks for the awesome library! I tried out `ExAws` for the first time tonight and ran into a small issue when attempting to list the objects in one of our companies' S3 buckets. I had been able to list buckets without issue using `ExAws.S3.list_buckets/0`, but the following failed:

``` elixir
iex> ExAws.list_objects("my-bucket-name")
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
stacktrace:
  (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
  (elixir) lib/enum.ex:116: Enumerable.reduce/3
  (elixir) lib/enum.ex:1486: Enum.reduce/3
  (elixir) lib/enum.ex:1025: Enum.into/4
  (ex_aws) lib/ex_aws/s3/parsers.ex:41: anonymous fn/1 in ExAws.S3.Parsers.list_objects_binaries/1
  (elixir) lib/enum.ex:1019: anonymous fn/4 in Enum.into/3
  (stdlib) lists.erl:1262: :lists.foldl/3
  (elixir) lib/enum.ex:1025: Enum.into/4
```

The root cause seemed to be that this bucket was not returning ownership information for its objects, and after the response XML was parsed, `ExAws.S3.Parsers.list_objects_binaries({:owner, nil})` would eventually be called, and fail when it tried to recurse with `nil`.

My quick solution was to reorder the anonymous function clauses to handle any nil values before matching specific keys (other than `:contents`, which should always be present.) It doesn't appear to break anything, but I'm not super-familiar with the library. If it needs some changes, I'm happy to take another stab. If this is a weird use case and it shouldn't be merged, I understand.