### PR TITLE
Be able to use ENV variables to define host parameter

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -42,8 +42,6 @@ defmodule ExAws.Config do
   def retrieve_runtime_config(%{config: config} = client) do
     new_config = config
     |> Enum.reduce(%{}, fn
-      {:host, host}, config ->
-        Map.put(config, :host, host)
       {k, v}, config ->
         case retrieve_runtime_value(v, client) do
           %{} = result -> Map.merge(config, result)


### PR DESCRIPTION
Following the discussion in https://github.com/CargoSense/ex_aws/issues/90

This PR removes the `{:host, host}, config ->` clause from `retrieve_runtime_config/2` to be able to set the host value within an ENV variable and be able to use `host: {:system, "AWS_HOST"}` in the `config*.exs`

I don't see any reason to keep this clause, but I just started using your project, so maybe this PR is a bit too rash.
At least it opens the discussion on this matter, since i'm stuck if i don't do this modification, and i'm obviously not fond to keep working with a fork to be able to use it.