### PR TITLE
Add port option to kinesis config

### DIFF
--- a/lib/ex_aws/kinesis/request.ex
+++ b/lib/ex_aws/kinesis/request.ex
@@ -20,8 +20,11 @@ defmodule ExAws.Kinesis.Request do
     {:ok, config[:json_codec].decode!(body)}
   end
 
-  defp url(%{scheme: scheme, host: host}) do
-    [scheme, host, "/"]
+  defp url(%{scheme: scheme, host: host, port: port}) do
+    [scheme, host, port |> port, "/"]
     |> IO.iodata_to_binary
   end
+
+  defp port(80), do: ""
+  defp port(p),  do: ":#{p}"
 end


### PR DESCRIPTION
Hi there,

I've been using [kinesalite](https://github.com/mhart/kinesalite) as a mock server to test the application I am writing. Even though I could have config kinesalite to set the port to to the default one, I think that having an option to explicitly set the port is a good idea, as the [dynamodb request module](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/dynamo/request.ex#L22-L28) is already doing.

Also, I didn't see any particular test I could verify this new changes. Maybe it wouldn't be a bad idea to refactor the request modules (now the dynamodb module and the kinesis module are almost 100% the same) and some test to it. I might be able to help if needed.

Thanks!