### PR TITLE
Allow empty responses from kinesis

### DIFF
--- a/lib/ex_aws/dynamo/request.ex
+++ b/lib/ex_aws/dynamo/request.ex
@@ -15,6 +15,7 @@ defmodule ExAws.Dynamo.Request do
   end
 
   def parse({:error, result}, _), do: {:error, result}
+  def parse({:ok, %{body: ""}}, config), do: {:ok, ""}
   def parse({:ok, %{body: body}}, config) do
     {:ok, config[:json_codec].decode!(body)}
   end


### PR DESCRIPTION
Hello again,

There are a few kinesis endpoints that return an empty response. For example, http://docs.aws.amazon.com/kinesis/latest/APIReference/API_DeleteStream.html

In those cases we can't parse the response coming from the server because it's not a valid JSON, it's just an empty string.

Also, I didn't see a simple way to add tests to this, because the integration test shouldn't modify the state, and all of these operations that returns an empty response, do modify the state (delete/create streams, removeTagsFromStream). On the other hand, the `kinesis_test` overrides the request function, to I can't use it either 