### PR TITLE
Remove virtual-style hosting

### DIFF
--- a/lib/ex_aws/s3/request.ex
+++ b/lib/ex_aws/s3/request.ex
@@ -23,7 +23,7 @@ defmodule ExAws.S3.Request do
   end
 
   def url(%{scheme: scheme, host: host}, bucket, path) do
-    [ scheme, host_and_bucket(host, bucket), ensure_slash(path) ]
+    [ scheme, [host, "/", bucket], ensure_slash(path) ]
     |> IO.iodata_to_binary
   end
 
@@ -34,12 +34,4 @@ defmodule ExAws.S3.Request do
 
   def ensure_slash("/" <> _ = path), do: path
   def ensure_slash(path), do:  "/" <> path
-
-  defp host_and_bucket(host, ""), do: host
-  defp host_and_bucket(host, bucket) do
-    case bucket |> String.contains?(".") do
-      true  -> [host, "/", bucket]
-      false -> [bucket, ".", host]
-    end
-  end
 end


### PR DESCRIPTION
When I setup a docker container running fakes3 at `http://s3`, the virtual-host style S3 buckets try to access `http://#{bucke}.s3` which results in an `[error] ExAws: HTTP ERROR: :nxdomain`. This removes virtual-hosted-style URLs in favor of the more consistent bucket path, which makes standing up fakes3 in a docker-compose cluster easier.