### PR TITLE
Fix 'could not find operation' error on SNS.

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -78,19 +78,19 @@ defmodule ExAws.SNS do
     |> Map.new
     |> camelize_keys
 
-    request(:list_topics, opts)
+    request("ListTopics", opts)
   end
 
   @doc "Create topic"
   @spec create_topic(topic_name :: topic_name) :: ExAws.Operation.Query.t
   def create_topic(topic_name) do
-    request(:create_topic, %{"Name" => topic_name})
+    request("CreateTopic", %{"Name" => topic_name})
   end
 
   @doc "Get topic attributes"
   @spec get_topic_attributes(topic_arn :: topic_arn) :: ExAws.Operation.Query.t
   def get_topic_attributes(topic_arn) do
-    request(:get_topic_attributes, %{"TopicArn" => topic_arn})
+    request("GetTopicAttributes", %{"TopicArn" => topic_arn})
   end
 
   @doc "Set topic attributes"
@@ -98,7 +98,7 @@ defmodule ExAws.SNS do
                                    attribute_value :: binary,
                                    topic_arn :: topic_arn) :: ExAws.Operation.Query.t
   def set_topic_attributes(attribute_name, attribute_value, topic_arn) do
-    request(:set_topic_attributes, %{
+    request("SetTopicAttributes", %{
       "AttributeName" => attribute_name |> camelize_key,
       "AttributeValue" => attribute_value,
       "TopicArn" => topic_arn
@@ -108,7 +108,7 @@ defmodule ExAws.SNS do
   @doc "Delete topic"
   @spec delete_topic(topic_arn :: topic_arn) :: ExAws.Operation.Query.t
   def delete_topic(topic_arn) do
-    request(:delete_topic, %{"TopicArn" => topic_arn})
+    request("DeleteTopic", %{"TopicArn" => topic_arn})
   end
 
   @type message_attribute :: %{
@@ -146,7 +146,7 @@ defmodule ExAws.SNS do
     |> Map.put("Message", message)
     |> Map.merge(message_attrs)
 
-    request(:publish, params)
+    request("Publish", params)
   end
 
   defp build_message_attributes(attrs) do

--- a/test/lib/ex_aws/sns_test.exs
+++ b/test/lib/ex_aws/sns_test.exs
@@ -1,0 +1,43 @@
+defmodule ExAws.SNSTest do
+  use ExUnit.Case, async: true
+  alias ExAws.SNS
+
+  test "#list_topics" do
+    expected = %{"Action" => "ListTopics"}
+    assert expected == SNS.list_topics().params
+  end
+
+  test "#create_topic" do
+    expected = %{"Action" => "CreateTopic", "Name" => "test_topic"}
+    assert expected == SNS.create_topic("test_topic").params
+  end
+
+  test "#get_topic_attributes" do
+    expected = %{"Action" => "GetTopicAttributes", "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic"}
+    assert expected == SNS.get_topic_attributes("arn:aws:sns:us-east-1:982071696186:test-topic").params
+  end
+
+  test "#set_topic_attributes" do
+    expected = %{
+      "Action" => "SetTopicAttributes",
+      "AttributeName" => "DeliverPolicy",
+      "AttributeValue" => "{\"http\":{\"defaultHealthyRetryPolicy\":{\"numRetries\":5}}}",
+      "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic"
+    }
+    assert expected == SNS.set_topic_attributes(:deliver_policy, "{\"http\":{\"defaultHealthyRetryPolicy\":{\"numRetries\":5}}}", "arn:aws:sns:us-east-1:982071696186:test-topic").params
+  end
+
+  test "#delete_topic" do
+    expected = %{"Action" => "DeleteTopic", "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic"}
+    assert expected == SNS.delete_topic("arn:aws:sns:us-east-1:982071696186:test-topic").params
+  end
+
+  test "#publish" do
+    expected = %{
+      "Action" => "Publish",
+      "Message" => "{\"message\": \"MyMessage\"}",
+      "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic"
+    }
+    assert expected == SNS.publish("{\"message\": \"MyMessage\"}", [topic_arn: "arn:aws:sns:us-east-1:982071696186:test-topic"]).params
+  end
+end


### PR DESCRIPTION
When I tried to use `SNS.publish/2` with the latest version, I got the following error.

```
{:error, {:http_error, 400, "<ErrorResponse xmlns=\"http://webservices.amazon.com/AWSFault/2005-15-09\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>InvalidAction</Code>\n    <Message>Could not find operation publish for version 2010-03-31</Message>\n  </Error>\n  <RequestId>xxxx</RequestId>\n</ErrorResponse>\n"}}
```

So, I've fixed this issue, and added some brief tests.