### PR TITLE
Fix syntax error in sample IAM policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Running the test suite for ex_aws requires a few things:
               "lambda:ListFunctions",
               "s3:ListAllMyBuckets",
               "sns:ListTopics",
-              "sqs:ListQueues",
+              "sqs:ListQueues"
           ],
           "Resource": "*"
       }


### PR DESCRIPTION
"This policy contains the following JSON error on line 11: Unexpected ']'"