### PR TITLE
make retry backoff exponential with jitter

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -1,6 +1,8 @@
 defmodule ExAws.Request do
   require Logger
   @max_attempts 10
+  @base_backoff_in_ms 10
+  @max_backoff_in_ms 10_000
 
   @moduledoc """
   Makes requests to AWS.
@@ -84,9 +86,11 @@ defmodule ExAws.Request do
     {:attempt, attempt + 1}
   end
 
-  # TODO: make exponential
-  # TODO: add jitter
   def backoff(attempt) do
-    :timer.sleep(attempt * 1000)
+    (@base_backoff_in_ms * :math.pow(2, attempt))
+    |> min(@max_backoff_in_ms)
+    |> trunc
+    |> :rand.uniform
+    |> :timer.sleep
   end
 end


### PR DESCRIPTION
I implemented exponential backoff with jitter based on the "full jitter" variant of the formula described at https://www.awsarchitectureblog.com/2015/03/backoff.html

The article didn't specify values for the @max_backoff_in_ms or @base_backoff_in_ms values. I picked 10 seconds for the max because that is how long the longest retry would be for the 10th attempt currently in master, and I chose 10ms for the base because that value resulted in a cap of around 10 seconds on the 10th attempt. Feel free to fiddle with those or with the formula.

sleep times between requests with this formula and base / max values are as follows:

attempt # | between 0 and x ms
----------|----------------------
1 | 20
2 | 40
3 | 80
4 | 160
5 | 320
6 | 640
7 | 1280
8 | 2560
9 | 5120
10 | 10000

Thanks!
Adam
