### PR TITLE
Add application platform support to SNS

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -116,14 +116,8 @@ defmodule ExAws.SNS do
   ######################
 
   @doc "Create plaform application"
-  def create_platform_application(name, :adm),
-    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADM"})
-  def create_platform_application(name, :adns),
-    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADNS"})
-  def create_platform_application(name, :adns_sandbox),
-    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADNS_SANDBOX"})
-  def create_platform_application(name, :gcm),
-    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "GCM"})
+  def create_platform_application(name, platform),
+    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => platform})
 
   @doc "Create platform endpoint"
   def create_platform_endpoint(platform_application_arn, token, custom_user_data \\ nil) do

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -112,6 +112,28 @@ defmodule ExAws.SNS do
     |> Map.put(param_root <> ".Value.DataType", data_type)
   end
 
+  ## Platform
+  ######################
+
+  @doc "Create plaform application"
+  def create_platform_application(name, :adm),
+    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADM"})
+  def create_platform_application(name, :adns),
+    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADNS"})
+  def create_platform_application(name, :adns_sandbox),
+    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "ADNS_SANDBOX"})
+  def create_platform_application(name, :gcm),
+    do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => "GCM"})
+
+  @doc "Create platform endpoint"
+  def create_platform_endpoint(platform_application_arn, token, custom_user_data \\ nil) do
+    request("CreatePlatformEndpoint", %{
+      "PlatformApplicationArn" => platform_application_arn,
+      "Token" => token,
+      "CustomUserData" => custom_user_data
+    })
+  end
+
   ## Request
   ######################
 

--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -115,11 +115,19 @@ defmodule ExAws.SNS do
   ## Platform
   ######################
 
+  @type platform_application_arn:: binary
+
   @doc "Create plaform application"
+  @spec create_platform_application(name :: binary, platform :: binary) :: ExAws.Operation.Query.t
   def create_platform_application(name, platform),
     do: request("CreatePlatformApplication", %{"Name" => name, "Platform" => platform})
 
   @doc "Create platform endpoint"
+  @spec create_platform_endpoint(platform_application_arn :: platform_application_arn,
+                                   token :: binary) :: ExAws.Operation.Query.t
+  @spec create_platform_endpoint(platform_application_arn :: platform_application_arn,
+                                   token :: binary,
+                                   custom_user_data :: binary) :: ExAws.Operation.Query.t
   def create_platform_endpoint(platform_application_arn, token, custom_user_data \\ nil) do
     request("CreatePlatformEndpoint", %{
       "PlatformApplicationArn" => platform_application_arn,

--- a/test/lib/ex_aws/sns_test.exs
+++ b/test/lib/ex_aws/sns_test.exs
@@ -32,6 +32,25 @@ defmodule ExAws.SNSTest do
     assert expected == SNS.delete_topic("arn:aws:sns:us-east-1:982071696186:test-topic").params
   end
 
+  test "#create_platform_application" do
+    expected = %{
+      "Action" => "CreatePlatformApplication",
+      "Name" => "ApplicationName",
+      "Platform" => "APNS"
+    }
+    assert expected == SNS.create_platform_application("ApplicationName", "APNS").params
+  end
+
+  test "#create_platform_endpoint" do
+    expected = %{
+      "Action" => "CreatePlatformEndpoint",
+      "CustomUserData" => "user data",
+      "PlatformApplicationArn" => "arn:aws:sns:us-west-1:00000000000:app/APNS/test-arn",
+      "Token" => "123abc456def"
+    }
+    assert expected == SNS.create_platform_endpoint("arn:aws:sns:us-west-1:00000000000:app/APNS/test-arn", "123abc456def", "user data").params
+  end
+
   test "#publish" do
     expected = %{
       "Action" => "Publish",


### PR DESCRIPTION
SNS has a couple of endpoints so you can use it to send push notifications to mobile devices and this PR adds support for that. I had trouble running the full test suite but `mix test test/lib/ex_aws/sns_test.exs` runs fine with no errors.