### PR TITLE
Add support for additional query parameters to S3.presigned_url

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -24,10 +24,10 @@ defmodule ExAws.Auth do
     [{"Authorization", auth_header} | headers ]
   end
 
-  def presigned_url(http_method, url, service, datetime, config, expires) do
+  def presigned_url(http_method, url, service, datetime, config, expires, query_params \\ []) do
     service = service_name(service)
     headers = presigned_url_headers(url)
-    query = presigned_url_query(service, datetime, config, expires)
+    query = presigned_url_query(service, datetime, config, expires, query_params)
     url = "#{url}?#{query}"
     signature = signature(http_method, url, headers, nil, service, datetime, config)
     "#{url}&X-Amz-Signature=#{signature}"
@@ -168,8 +168,11 @@ defmodule ExAws.Auth do
     [{"host", uri.host}]
   end
 
-  defp presigned_url_query(service, datetime, config, expires) do
-    "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+  defp presigned_url_query(service, datetime, config, expires, query_params) do
+    Enum.reduce(query_params, "", fn({key,value}, acc) ->
+      acc <> "#{to_string(key)}=#{to_string(value)}&"
+    end)
+    <> "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
     <> "X-Amz-Credential=#{uri_encode(credentials(service, datetime, config))}&"
     <> "X-Amz-Date=#{amz_date(datetime)}&"
     <> "X-Amz-Expires=#{expires}&"

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -835,7 +835,8 @@ defmodule ExAws.S3 do
   the hostname. This will cause the returned URL to be 'http' and not 'https'.
 
   Additional (signed) query parameters can be added to the url by setting option param
-  `:query_params` to a list of `{"key", "value"}` pairs.
+  `:query_params` to a list of `{"key", "value"}` pairs. Useful if you uploading parts of
+  a multipart upload directly from the browser.
   """
   @spec presigned_url(config :: %{}, http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: {:ok, binary} | {:error, binary}
   @one_week 60 * 60 * 24 * 7

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -835,7 +835,7 @@ defmodule ExAws.S3 do
   the hostname. This will cause the returned URL to be 'http' and not 'https'.
 
   Additional (signed) query parameters can be added to the url by setting option param
-  `:query_params` to a list of `{"key", "value"}` pairs. Useful if you uploading parts of
+  `:query_params` to a list of `{"key", "value"}` pairs. Useful if you are uploading parts of
   a multipart upload directly from the browser.
   """
   @spec presigned_url(config :: %{}, http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: {:ok, binary} | {:error, binary}

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -83,7 +83,8 @@ defmodule ExAws.S3 do
 
   @type presigned_url_opts :: [
     expires_in: integer,
-    virtual_host: boolean
+    virtual_host: boolean,
+    query_params: [{:key, binary}]
   ]
 
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]
@@ -832,18 +833,22 @@ defmodule ExAws.S3 do
 
   When option param :virtual_host is `true`, the {#bucket} name will be used as
   the hostname. This will cause the returned URL to be 'http' and not 'https'.
+
+  Additional (signed) query parameters can be added to the url by setting option param
+  `:query_params` to a list of `{"key", "value"}` pairs.
   """
   @spec presigned_url(config :: %{}, http_method :: atom, bucket :: binary, object :: binary, opts :: presigned_url_opts) :: {:ok, binary} | {:error, binary}
   @one_week 60 * 60 * 24 * 7
   def presigned_url(config, http_method, bucket, object, opts \\ []) do
     expires_in = Keyword.get(opts, :expires_in, 3600)
     virtual_host = Keyword.get(opts, :virtual_host, false)
+    query_params = Keyword.get(opts, :query_params, [])
     case expires_in > @one_week do
       true -> {:error, "expires_in_exceeds_one_week"}
       false ->
         url = url_to_sign(bucket, object, config, virtual_host)
         datetime = :calendar.universal_time
-        {:ok, ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in)}
+        {:ok, ExAws.Auth.presigned_url(http_method, url, :s3, datetime, config, expires_in, query_params)}
     end
   end
 

--- a/test/lib/ex_aws/auth_test.exs
+++ b/test/lib/ex_aws/auth_test.exs
@@ -35,4 +35,34 @@ defmodule ExAws.AuthTest do
 
     assert expected == actual
   end
+
+  test "presigned url with query params" do
+    # Data taken from example in:
+    # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/test.txt"
+    service = :s3
+    datetime = {{2013, 5, 24}, {0, 0, 0}}
+    config = [
+      access_key_id: "AKIAIOSFODNN7EXAMPLE",
+      secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1"
+     ]
+    expires = 86400
+    query_params = [partNum: "1", uploadId: "sample.upload.id"]
+    actual = ExAws.Auth.presigned_url(http_method, url, service, datetime, config, expires, query_params)
+
+    expected =
+      "https://examplebucket.s3.amazonaws.com/test.txt" <>
+      "?partNum=1" <>
+      "&uploadId=sample.upload.id" <>
+      "&X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
+      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request" <>
+      "&X-Amz-Date=20130524T000000Z" <>
+      "&X-Amz-Expires=86400" <>
+      "&X-Amz-SignedHeaders=host" <>
+      "&X-Amz-Signature=6b0ff5ea4c0100681f6350a94544d7155410a3c0ffa15b285fc1e8ab0f50ccb2"
+
+    assert expected == actual
+  end
 end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -119,6 +119,24 @@ defmodule ExAws.S3Test do
     assert_pre_signed_url(url, "https://bucket.s3.amazonaws.com/foo.txt", "100")
   end
 
+  test "#presigned_url passing query_params option" do
+    query_params = [
+      key_one: "value_one",
+      key_two: "value_two"
+    ]
+    {:ok, url} = S3.presigned_url(config(), :get, "bucket", "foo.txt", [query_params: query_params])
+    uri = URI.parse(url)
+    actual_query = URI.query_decoder(uri.query) |> Enum.map(&(&1))
+    assert [{"key_one", "value_one"},
+            {"key_two", "value_two"},
+            {"X-Amz-Algorithm", "AWS4-HMAC-SHA256"},
+            {"X-Amz-Credential", _},
+            {"X-Amz-Date", _},
+            {"X-Amz-Expires", _},
+            {"X-Amz-SignedHeaders", "host"},
+            {"X-Amz-Signature", _}] = actual_query
+  end
+
   test "#presigned_url file is path with slash" do
     {:ok, url} = S3.presigned_url(config(), :get, "bucket", "/foo/bar.txt")
     assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo/bar.txt", "3600")


### PR DESCRIPTION
Added an optional :query_params field to presigned_url_opts

If this is set to an array of key value pairs [{"key", "value}], then those are added to the url to be signed and included in the calculated signature. This is required to enable uploading parts of a multipart upload directly from the browser to S3.

Added tests to s3_test.exs and auth_test.exs and explained it in the docs for presigned_url.