### PR TITLE
improve jsx.ex

### DIFF
--- a/lib/ex_aws/json/codec.ex
+++ b/lib/ex_aws/json/codec.ex
@@ -7,7 +7,7 @@ defmodule ExAws.JSON.Codec do
 
   See the contents of `ExAws.JSON.JSX` for an example of an alternative implementation.
   ## Example
-  Here for example is the code required to make HTTPotion comply with this spec.
+  Here for example is the code required to make jsx comply with this spec.
 
   In your config you would do:
 
@@ -23,26 +23,27 @@ defmodule ExAws.JSON.Codec do
     @moduledoc false
 
     def encode!(%{} = map) do
-      map
-      |> Map.to_list
-      |> :jsx.encode
-      |> case do
-        "[]" -> "{}"
-        val -> val
-      end
+      map |> :jsx.encode
     end
 
     def encode(map) do
-      {:ok, encode!(map)}
+      try do
+        {:ok, encode!(map)}
+      rescue
+        ArgumentError -> {:error, :badarg}
+      end
     end
 
     def decode!(string) do
-      :jsx.decode(string)
-      |> Map.new
+      :jsx.decode(string, [:return_maps])
     end
 
     def decode(string) do
-      {:ok, decode!(string)}
+      try do
+        {:ok, decode!(string)}
+      rescue
+        ArgumentError -> {:error, :badarg}
+      end
     end
   end
   ```

--- a/lib/ex_aws/json/jsx.ex
+++ b/lib/ex_aws/json/jsx.ex
@@ -4,25 +4,26 @@ defmodule ExAws.JSON.JSX do
   @moduledoc false
 
   def encode!(%{} = map) do
-    map
-    |> Map.to_list
-    |> :jsx.encode
-    |> case do
-      "[]" -> "{}"
-      val -> val
-    end
+    map |> :jsx.encode
   end
 
   def encode(map) do
-    {:ok, encode!(map)}
+    try do
+      {:ok, encode!(map)}
+    rescue
+      ArgumentError -> {:error, :badarg}
+    end
   end
 
   def decode!(string) do
-    :jsx.decode(string)
-    |> Map.new
+    :jsx.decode(string, [:return_maps])
   end
 
   def decode(string) do
-    {:ok, decode!(string)}
+    try do
+      {:ok, decode!(string)}
+    rescue
+      ArgumentError -> {:error, :badarg}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ExAws.Mixfile do
       {:ex_doc, "~> 0.11.4", only: :dev},
       {:hackney, "~> 1.5", optional: true},
       {:poison, "~> 1.2 or ~> 2.0", optional: true},
-      {:jsx, "~> 2.5", optional: true},
+      {:jsx, "~> 2.8", optional: true},
       {:gen_stage, ">= 0.0.0"},
       {:dialyze, "~> 0.2.0", only: :dev},
     ]


### PR DESCRIPTION
return proper error tuples from `encode/1` and `decode/1` and take advantage of jsx support for maps