### PR TITLE
Extracted Auth.Signatures into separate module

### DIFF
--- a/lib/ex_aws/auth/credentials.ex
+++ b/lib/ex_aws/auth/credentials.ex
@@ -1,0 +1,14 @@
+defmodule ExAws.Auth.Credentials do
+  @moduledoc false
+
+  import ExAws.Auth.Utils, only: [date: 1]
+
+  def generate_credential_v4(service, datetime, config) do
+    scope = generate_credential_scope_v4(service, datetime, config)
+    "#{config[:access_key_id]}/#{scope}"
+  end
+
+  def generate_credential_scope_v4(service, datetime, config) do
+    "#{date(datetime)}/#{config[:region]}/#{service}/aws4_request"
+  end
+end

--- a/lib/ex_aws/auth/signatures.ex
+++ b/lib/ex_aws/auth/signatures.ex
@@ -1,0 +1,19 @@
+defmodule ExAws.Auth.Signatures do
+  @moduledoc false
+  import ExAws.Auth.Utils, only: [hmac_sha256: 2, date: 1, bytes_to_hex: 1]
+
+  def generate_signature_v4(service, config, datetime, string_to_sign) do
+    service
+    |> signing_key(datetime, config)
+    |> hmac_sha256(string_to_sign)
+    |> bytes_to_hex
+  end
+
+  defp signing_key(service, datetime, config) do
+    ["AWS4", config[:secret_access_key]]
+    |> hmac_sha256(date(datetime))
+    |> hmac_sha256(config[:region])
+    |> hmac_sha256(service)
+    |> hmac_sha256("aws4_request")
+  end
+end

--- a/test/lib/ex_aws/auth/credentials_test.exs
+++ b/test/lib/ex_aws/auth/credentials_test.exs
@@ -1,0 +1,26 @@
+defmodule ExAws.Auth.CredentialsTest do
+  use ExUnit.Case, async: true
+
+  alias ExAws.Auth.Credentials
+
+  test "generate_credential_v4/3 returns the correct value" do
+    datetime = {{2013, 5, 24}, {0, 0, 0}}
+    config = [
+      access_key_id: "AKIAIOSFODNN7EXAMPLE",
+      region: "us-east-1"
+    ]
+
+    scope = Credentials.generate_credential_v4("s3", datetime, config)
+
+    assert scope == "AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"
+  end
+
+  test "generate_credential_scope_v4/3 returns the correct value" do
+    datetime = {{2013, 5, 24}, {0, 0, 0}}
+    config = [region: "us-east-1"]
+
+    scope = Credentials.generate_credential_scope_v4("s3", datetime, config)
+
+    assert scope == "20130524/us-east-1/s3/aws4_request"
+  end
+end

--- a/test/lib/ex_aws/auth/signatures_test.exs
+++ b/test/lib/ex_aws/auth/signatures_test.exs
@@ -1,0 +1,19 @@
+defmodule ExAws.Auth.SignaturesTest do
+  use ExUnit.Case, async: true
+  alias ExAws.Auth.Signatures
+
+  describe "generate_signature_v4/4" do
+    test "with a basic string to sign" do
+      config = ExAws.Config.new(:s3, [
+        access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1"
+      ])
+      datetime = {{2016,8,29},{19,41,33}}
+
+      signature = Signatures.generate_signature_v4("s3", config, datetime, "hello world")
+
+      assert signature == "690b8431208dae486dd00df93bde9370d8aba587098b9a26bfd07c259df395c9"
+    end
+  end
+end


### PR DESCRIPTION
I am working on adding S3 presigned post functionality (#114) and found it a little confusing how the actual signature was being generated. I extracted an `ExAws.Auth.Signatures` module to make this more clear, and so I can share this functionality with the PresignedPostGenerator module I'm working on.