### PR TITLE
Implement ExAws.Operation, for ExAws.Operation.RestQuery

### DIFF
--- a/lib/ex_aws/operation/rest_query.ex
+++ b/lib/ex_aws/operation/rest_query.ex
@@ -5,4 +5,31 @@ defmodule ExAws.Operation.RestQuery do
     params: %{},
     service: nil,
   ]
+
+  @type t :: %__MODULE__{}
+end
+
+defimpl ExAws.Operation, for: ExAws.Operation.RestQuery do
+  def perform(operation, config) do
+    query = operation.params
+    |> URI.encode_query
+
+    headers = [
+      {"content-type", "application/x-www-form-urlencoded"},
+    ]
+
+    ExAws.Request.request(operation.http_method, url(config, operation.path), query, headers, config, operation.service)
+  end
+
+  def url(%{scheme: scheme, host: host, port: port}, queue_name) do
+    [
+      scheme,
+      host,
+      port |> port(),
+      queue_name
+    ] |> IO.iodata_to_binary
+  end
+
+  defp port(80), do: ""
+  defp port(p),  do: ":#{p}"
 end

--- a/test/lib/ex_aws/ec2/integration_test.exs
+++ b/test/lib/ex_aws/ec2/integration_test.exs
@@ -1,0 +1,8 @@
+defmodule ExAws.EC2.IntegrationTest do
+  use ExUnit.Case, async: true
+
+  test "#describe_instances" do
+    assert {:ok, %{body: body}} = ExAws.EC2.describe_instances |> ExAws.request
+    assert body |> String.contains?("DescribeInstancesResponse")
+  end
+end


### PR DESCRIPTION
I want to get the result of EC2-API running such code.

```
ExAws.EC2.describe_instances
|> ExAws.request
```

so, implementation of the ExAws.Operation Protocol to ExAwsOperation.RestQuery.