### PR TITLE
Update Credentials functions arg order to match Signatures arg order

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -44,7 +44,7 @@ defmodule ExAws.Auth do
   defp auth_header(http_method, url, headers, body, service, datetime, config) do
     signature = signature(http_method, url, headers, body, service, datetime, config)
     [
-      "AWS4-HMAC-SHA256 Credential=", Credentials.generate_credential_v4(service, datetime, config), ",",
+      "AWS4-HMAC-SHA256 Credential=", Credentials.generate_credential_v4(service, config, datetime), ",",
       "SignedHeaders=", signed_headers(headers), ",",
       "Signature=", signature
     ] |> IO.iodata_to_binary
@@ -100,7 +100,7 @@ defmodule ExAws.Auth do
     """
     AWS4-HMAC-SHA256
     #{amz_date(datetime)}
-    #{Credentials.generate_credential_scope_v4(service, datetime, config)}
+    #{Credentials.generate_credential_scope_v4(service, config, datetime)}
     #{request}
     """
     |> String.rstrip
@@ -168,7 +168,7 @@ defmodule ExAws.Auth do
       acc <> "#{to_string(key)}=#{to_string(value)}&"
     end)
     <> "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
-    <> "X-Amz-Credential=#{uri_encode(Credentials.generate_credential_v4(service, datetime, config))}&"
+    <> "X-Amz-Credential=#{uri_encode(Credentials.generate_credential_v4(service, config, datetime))}&"
     <> "X-Amz-Date=#{amz_date(datetime)}&"
     <> "X-Amz-Expires=#{expires}&"
     <> "X-Amz-SignedHeaders=host"

--- a/lib/ex_aws/auth/credentials.ex
+++ b/lib/ex_aws/auth/credentials.ex
@@ -3,12 +3,12 @@ defmodule ExAws.Auth.Credentials do
 
   import ExAws.Auth.Utils, only: [date: 1]
 
-  def generate_credential_v4(service, datetime, config) do
-    scope = generate_credential_scope_v4(service, datetime, config)
+  def generate_credential_v4(service, config, datetime) do
+    scope = generate_credential_scope_v4(service, config, datetime)
     "#{config[:access_key_id]}/#{scope}"
   end
 
-  def generate_credential_scope_v4(service, datetime, config) do
+  def generate_credential_scope_v4(service, config, datetime) do
     "#{date(datetime)}/#{config[:region]}/#{service}/aws4_request"
   end
 end

--- a/test/lib/ex_aws/auth/credentials_test.exs
+++ b/test/lib/ex_aws/auth/credentials_test.exs
@@ -10,7 +10,7 @@ defmodule ExAws.Auth.CredentialsTest do
       region: "us-east-1"
     ]
 
-    scope = Credentials.generate_credential_v4("s3", datetime, config)
+    scope = Credentials.generate_credential_v4("s3", config, datetime)
 
     assert scope == "AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"
   end
@@ -19,7 +19,7 @@ defmodule ExAws.Auth.CredentialsTest do
     datetime = {{2013, 5, 24}, {0, 0, 0}}
     config = [region: "us-east-1"]
 
-    scope = Credentials.generate_credential_scope_v4("s3", datetime, config)
+    scope = Credentials.generate_credential_scope_v4("s3", config, datetime)
 
     assert scope == "20130524/us-east-1/s3/aws4_request"
   end


### PR DESCRIPTION
I just realized right after you committed #214, the argument order of functions in the `Credentials` module don't match the argument order in the `Signatures` module.

Here are how they are currently

```elixir
Credentials.generate_credential_scope_v4(service, datetime, config)
Signatures.generate_signature_v4(service, config, datetime, string_to_sign)
```
This change updates the argument order of functions in the `Credentials` module to match the argument order of functions in the `Signatures` module.

```elixir
Credentials.generate_credential_scope_v4(service, config, datetime)
Signatures.generate_signature_v4(service, config, datetime, string_to_sign)
```

Sorry about this oversight.