### PR TITLE
Add a policy of ec2 in order to pass the ec2-integration-test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ Running the test suite for ex_aws requires a few things:
               "lambda:ListFunctions",
               "s3:ListAllMyBuckets",
               "sns:ListTopics",
-              "sqs:ListQueues"
+              "sqs:ListQueues",
+              "ec2:DescribeInstances"
           ],
           "Resource": "*"
       }


### PR DESCRIPTION
In order to in pass the `test/lib/ex_aws/ec2/integration_test.exs`  of TravisCI, 
you need to add the EC2 of the policy to the IAM.

Can you add the policy of EC2 to IAM that are used in TravisCI?


