### PR TITLE
Add clear error when SweetXML is missing

### DIFF
--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -1,11 +1,3 @@
-defmodule ExAws.Error.SweetXMLNotFound do
-  defexception message: """
-    The package sweet_xml is not found, and needs to be included in your
-    application. If it is loaded, make sure it is loaded before ex_aws in your
-    application list.
-    """
-end
-
 if Code.ensure_loaded?(SweetXml) do
   defmodule ExAws.S3.Parsers do
     import SweetXml, only: [sigil_x: 2]
@@ -76,12 +68,16 @@ if Code.ensure_loaded?(SweetXml) do
   end
 else
   defmodule ExAws.S3.Parsers do
-    alias ExAws.Error.SweetXMLNotFound
+    @error_message """
+      The package sweet_xml is not found, and needs to be included in your
+      application. If it is loaded, make sure it is loaded before ex_aws in your
+      application list.
+      """
 
-    def parse_list_objects(val), do: raise SweetXMLNotFound
-    def parse_initiate_multipart_upload(val), do: raise SweetXMLNotFound
-    def parse_upload_part_copy(val), do: raise SweetXMLNotFound
-    def parse_complete_multipart_upload(val), do: raise SweetXMLNotFound
-    def parse_list_parts(val), do: raise SweetXMLNotFound
+    def parse_list_objects(val), do: raise @error_message
+    def parse_initiate_multipart_upload(val), do: raise @error_message
+    def parse_upload_part_copy(val), do: raise @error_message
+    def parse_complete_multipart_upload(val), do: raise @error_message
+    def parse_list_parts(val), do: raise @error_message
   end
 end

--- a/lib/ex_aws/s3/parsers.ex
+++ b/lib/ex_aws/s3/parsers.ex
@@ -1,3 +1,11 @@
+defmodule ExAws.Error.SweetXMLNotFound do
+  defexception message: """
+    The package sweet_xml is not found, and needs to be included in your
+    application. If it is loaded, make sure it is loaded before ex_aws in your
+    application list.
+    """
+end
+
 if Code.ensure_loaded?(SweetXml) do
   defmodule ExAws.S3.Parsers do
     import SweetXml, only: [sigil_x: 2]
@@ -68,11 +76,12 @@ if Code.ensure_loaded?(SweetXml) do
   end
 else
   defmodule ExAws.S3.Parsers do
-    def parse_list_objects(val), do: val
-    def parse_initiate_multipart_upload(val), do: val
-    def parse_upload_part_copy(val), do: val
-    def parse_complete_multipart_upload(val), do: val
-    def parse_list_parts(val), do: val
-  end
+    alias ExAws.Error.SweetXMLNotFound
 
+    def parse_list_objects(val), do: raise SweetXMLNotFound
+    def parse_initiate_multipart_upload(val), do: raise SweetXMLNotFound
+    def parse_upload_part_copy(val), do: raise SweetXMLNotFound
+    def parse_complete_multipart_upload(val), do: raise SweetXMLNotFound
+    def parse_list_parts(val), do: raise SweetXMLNotFound
+  end
 end


### PR DESCRIPTION
In the docs it is not really clear you need to add the package sweet_xml in order to upload files to amazon S3. It fails with a cryptic error.

In this pull request I add a more clear error if the sweet_xml app is not loaded.