### PR TITLE
Fix some issues in generating process of presigned url

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -168,13 +168,13 @@ defmodule ExAws.Auth do
       acc <> "#{to_string(key)}=#{to_string(value)}&"
     end)
     <> "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
-    <> "X-Amz-Credential=#{uri_encode(Credentials.generate_credential_v4(service, config, datetime))}&"
+    <> "X-Amz-Credential=#{Credentials.generate_credential_v4(service, config, datetime)}&"
     <> "X-Amz-Date=#{amz_date(datetime)}&"
     <> "X-Amz-Expires=#{expires}&"
     <> "X-Amz-SignedHeaders=host"
     <> case config[:security_token] do
          nil -> ""
-         token -> "&X-Amz-Security-Token=#{uri_encode(token)}"
+         token -> "&X-Amz-Security-Token=#{token}"
        end
   end
 end

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -33,9 +33,7 @@ defmodule ExAws.Auth do
 
     org_query_params = query_params |> Enum.map(fn({k, v}) -> {to_string(k), v} end)
     amz_query_params = build_amz_query_params(service, datetime, config, expires)
-    {org_query, amz_query} = [org_query_params, amz_query_params]
-    |> Enum.map(&(canonical_query_params(&1)))
-    |> List.to_tuple
+    [org_query, amz_query] = [org_query_params, amz_query_params] |> Enum.map(&canonical_query_params/1)
     query_to_sign = org_query_params ++ amz_query_params |> canonical_query_params
     query_for_url = if Enum.count(org_query_params) == 0 do amz_query else org_query <> "&" <> amz_query end
 

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -30,7 +30,8 @@ defmodule ExAws.Auth do
   def presigned_url(http_method, url, service, datetime, config, expires, query_params \\ []) do
     service = service_name(service)
     headers = presigned_url_headers(url)
-    query = presigned_url_query(service, datetime, config, expires, query_params)
+    query = presigned_url_query(service, datetime, config, expires, query_params) |> canonical_query_params
+
     url = "#{url}?#{query}"
     signature = signature(http_method, url, headers, nil, service, datetime, config)
     "#{url}&X-Amz-Signature=#{signature}"
@@ -61,8 +62,6 @@ defmodule ExAws.Auth do
     uri = URI.parse(url)
     http_method = http_method |> method_string |> String.upcase
 
-    query_params = uri.query |> canonical_query_params
-
     headers = headers |> canonical_headers
     header_string = headers
     |> Enum.map(fn {k, v} -> "#{k}:#{remove_dup_spaces(to_string(v))}" end)
@@ -80,7 +79,7 @@ defmodule ExAws.Auth do
     [
       http_method, "\n",
       uri_encode(uri.path), "\n",
-      query_params, "\n",
+      uri.query || "", "\n",
       header_string, "\n",
       "\n",
       signed_headers_list, "\n",

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -35,7 +35,7 @@ defmodule ExAws.Auth do
     amz_query_params = build_amz_query_params(service, datetime, config, expires)
     [org_query, amz_query] = [org_query_params, amz_query_params] |> Enum.map(&canonical_query_params/1)
     query_to_sign = org_query_params ++ amz_query_params |> canonical_query_params
-    query_for_url = if Enum.count(org_query_params) == 0 do amz_query else org_query <> "&" <> amz_query end
+    query_for_url = if Enum.any?(org_query_params), do: org_query <> "&" <> amz_query, else: amz_query
 
     uri = URI.parse(url)
     path = uri_encode(uri.path)

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -35,7 +35,7 @@ defmodule ExAws.Auth do
     uri = URI.parse(url)
     path = uri_encode(uri.path)
     signature = signature(http_method, path, query, headers, nil, service, datetime, config)
-    "#{uri.scheme}://#{uri.host}#{path}?#{query}&X-Amz-Signature=#{signature}"
+    "#{uri.scheme}://#{uri.authority}#{path}?#{query}&X-Amz-Signature=#{signature}"
   end
 
   defp handle_temp_credentials(headers, %{security_token: token}) do

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -116,7 +116,7 @@ defmodule ExAws.Auth do
   defp canonical_query_params(nil), do: ""
   defp canonical_query_params(params) do
     params
-    |> URI.query_decoder
+    |> String.split("&") |> Enum.map(&List.to_tuple(String.split(&1, "=")))
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
     |> Enum.map_join("&", &pair/1)
   end

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -121,15 +121,15 @@ defmodule ExAws.Auth do
   end
 
   defp canonical_query_params(nil), do: ""
-  defp canonical_query_params(params) when is_binary(params) do
-    params
-    |> String.split("&") |> Enum.map(&List.to_tuple(String.split(&1, "=")))
-    |> canonical_query_params
-  end
   defp canonical_query_params(params) when is_list(params) do
     params
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
     |> Enum.map_join("&", &pair/1)
+  end
+  defp canonical_query_params(params) do
+    params
+    |> String.split("&") |> Enum.map(&List.to_tuple(String.split(&1, "=")))
+    |> canonical_query_params
   end
 
   defp pair({k, _}) when is_list(k) do

--- a/test/lib/ex_aws/auth_test.exs
+++ b/test/lib/ex_aws/auth_test.exs
@@ -58,13 +58,13 @@ defmodule ExAws.AuthTest do
 
     expected =
       "https://examplebucket.s3.amazonaws.com/test.txt" <>
-      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
+      "?partNumber=1" <>
+      "&uploadId=sample.upload.id" <>
+      "&X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
       "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request" <>
       "&X-Amz-Date=20130524T000000Z" <>
       "&X-Amz-Expires=86400" <>
       "&X-Amz-SignedHeaders=host" <>
-      "&partNumber=1" <>
-      "&uploadId=sample.upload.id" <>
       "&X-Amz-Signature=1fdac5451b2996880dc23162853ce76e4cf0a05257e430aec59e309ecd126ade"
 
     assert expected == actual

--- a/test/lib/ex_aws/auth_test.exs
+++ b/test/lib/ex_aws/auth_test.exs
@@ -1,12 +1,16 @@
 defmodule ExAws.AuthTest do
   use ExUnit.Case, async: true
   import ExAws.Auth, only: [
-    build_canonical_request: 4
+    build_canonical_request: 5
+  ]
+  import ExAws.Auth.Utils, only: [
+    uri_encode: 1
   ]
 
   test "build_canonical_request can handle : " do
     expected = "GET\n/bar%3Abaz%40blag\n\n\n\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    assert build_canonical_request(:get, "http://foo.com/bar:baz@blag", %{}, "") == expected
+    path = URI.parse("http://foo.com/bar:baz@blag").path |> uri_encode
+    assert build_canonical_request(:get, path, "", %{}, "") == expected
   end
 
   test "presigned url" do
@@ -27,7 +31,7 @@ defmodule ExAws.AuthTest do
     expected =
       "https://examplebucket.s3.amazonaws.com/test.txt" <>
       "?X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
-      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request" <>
+      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request" <>
       "&X-Amz-Date=20130524T000000Z" <>
       "&X-Amz-Expires=86400" <>
       "&X-Amz-SignedHeaders=host" <>
@@ -39,7 +43,7 @@ defmodule ExAws.AuthTest do
   test "presigned url with query params" do
     # Data taken from example in:
     # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
-    http_method = :get
+    http_method = :put
     url = "https://examplebucket.s3.amazonaws.com/test.txt"
     service = :s3
     datetime = {{2013, 5, 24}, {0, 0, 0}}
@@ -49,19 +53,19 @@ defmodule ExAws.AuthTest do
       region: "us-east-1"
      ]
     expires = 86400
-    query_params = [partNum: "1", uploadId: "sample.upload.id"]
+    query_params = [partNumber: 1, uploadId: "sample.upload.id"]
     actual = ExAws.Auth.presigned_url(http_method, url, service, datetime, config, expires, query_params)
 
     expected =
       "https://examplebucket.s3.amazonaws.com/test.txt" <>
-      "?partNum=1" <>
-      "&uploadId=sample.upload.id" <>
-      "&X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
-      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request" <>
+      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
+      "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request" <>
       "&X-Amz-Date=20130524T000000Z" <>
       "&X-Amz-Expires=86400" <>
       "&X-Amz-SignedHeaders=host" <>
-      "&X-Amz-Signature=6b0ff5ea4c0100681f6350a94544d7155410a3c0ffa15b285fc1e8ab0f50ccb2"
+      "&partNumber=1" <>
+      "&uploadId=sample.upload.id" <>
+      "&X-Amz-Signature=1fdac5451b2996880dc23162853ce76e4cf0a05257e430aec59e309ecd126ade"
 
     assert expected == actual
   end


### PR DESCRIPTION
Fix some issues in generating process of presigned url

Summary
* Remove unnecessary url encoding/decoding
 * No need to replace "+" to " "
* Use canonical query in both query to sign and query of result `presigned_url`
* Keep ordering of original query in presigned url
* Update test cases
 * expected `X-Amz-Signature`s are calculated by using https://github.com/kenrota/scriptbox/blob/master/ruby/gen_presigned_url_base_on_aws_example.rb
