### PR TITLE
Remove `AWS_SECURITY_TOKEN` from common setting

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -7,7 +7,6 @@ defmodule ExAws.Config.Defaults do
   @common %{
     access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
     secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
-    security_token: [{:system, "AWS_SECURITY_TOKEN"}, :instance_role],
     http_client: ExAws.Request.Hackney,
     json_codec: Poison,
     retries: [


### PR DESCRIPTION
Remove `AWS_SECURITY_TOKEN` from common setting, because that is optional setting.