### PR TITLE
Added :phone_number to SNS publish_opts & updated spec.

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -67,13 +67,14 @@ defmodule ExAws.SNS do
     {:message_attributes, [message_attribute]} |
     {:message_structure, :json} |
     {:subject, binary} |
+    {:phone_number, binary} | 
     {:target_arn, binary} |
     {:topic_arn, binary}]
 
   @doc """
   Publish message to a target/topic ARN
 
-  You must set either :target_arn or :topic_arn but not both via the options argument.
+  You must set either :phone_number, :target_arn or :topic_arn but only one, via the options argument.
 
   Do NOT assume that because your message is a JSON blob that you should set
   message_structure: to :json. This has a very specific meaning, please see


### PR DESCRIPTION
As per AWS SNS [API docs](http://docs.aws.amazon.com/sns/latest/api/API_Publish.html), you can specify PhoneNumber as a request parameter; provided you don't specify :target_arn or :topic_arn. 
This allows for the sending of SMS on a one-time basis rather than to subscribers of a particular topic (useful for sending one-time access codes etc).

Whilst the code still executes without this change, it should probably be made to clarify the options that `publish_opts` has, and should help towards breaking changes in the future.

Tests are passing as before.
