### PR TITLE
Handled Message Attributes

### DIFF
--- a/lib/ex_aws/sqs.ex
+++ b/lib/ex_aws/sqs.ex
@@ -333,7 +333,7 @@ defmodule ExAws.SQS do
   end
 
   defp format_message_attribute({attribute, index}) do
-    %{"MessageAttributeName.#{index + 1}" => attribute}
+    %{"MessageAttributeName.#{index + 1}" => to_string(attribute)}
   end
 
   defp format_message_attributes(:all) do

--- a/lib/ex_aws/sqs.ex
+++ b/lib/ex_aws/sqs.ex
@@ -183,7 +183,7 @@ defmodule ExAws.SQS do
 
   @type receive_message_opts :: [
     {:attribute_names, :all | [sqs_message_attribute_name, ...]} |
-    {:message_attribute_names, :all | [String.t, ...]} |
+    {:message_attribute_names, :all | [String.Chars.t, ...]} |
     {:max_number_of_messages, 1..10} |
     {:visibility_timeout, 0..43200} |
     {:wait_time_seconds, 0..20}

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -204,15 +204,15 @@ if Code.ensure_loaded?(SweetXml) do
       end
     end
 
-    defp parse_attribute_value(<<"String", _rest :: binary>>, %{string_value: string_value}) do
+    defp parse_attribute_value(<<"String", _ :: binary>>, %{string_value: string_value}) do
       string_value
     end
 
-    defp parse_attribute_value(<<"Binary", _rest :: binary>>, %{binary_value: b64_encoded}) do
+    defp parse_attribute_value(<<"Binary", _ :: binary>>, %{binary_value: b64_encoded}) do
       :base64.decode(b64_encoded)
     end
 
-    defp parse_attribute_value(<<"Number", _rest :: binary>>, %{string_value: string_value}) do
+    defp parse_attribute_value(<<"Number", _ :: binary>>, %{string_value: string_value}) do
       try do
         String.to_integer(string_value)
       rescue ArgumentError ->

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -209,7 +209,12 @@ if Code.ensure_loaded?(SweetXml) do
     end
 
     defp parse_attribute_value(<<"Binary", _ :: binary>>, %{binary_value: b64_encoded}) do
-      :base64.decode(b64_encoded)
+      case Base.decode64(b64_encoded) do
+        {:ok, decoded} ->
+          decoded
+        _ ->
+          b64_encoded
+      end
     end
 
     defp parse_attribute_value(<<"Number", _ :: binary>>, %{string_value: string_value}) do

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -186,7 +186,7 @@ if Code.ensure_loaded?(SweetXml) do
           ^attr ->
             Map.put(acc, name, attr)
           parsed ->
-            Map.put(acc, name, %{value: parsed, data_type: data_type})
+            Map.put(acc, name, Map.put(attr, :value, parsed))
         end
       end)
     end

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -109,15 +109,19 @@ if Code.ensure_loaded?(SweetXml) do
                             ~x"./Attribute"lo,
                             name: ~x"./Name/text()"s,
                             value: ~x"./Value/text()"s |> SweetXml.transform_by(&try_cast_to_number/1)
+                          ],
+                          message_attributes: [
+                            ~x"./MessageAttribute"lo,
+                            name: ~x"./Name/text()"s,
+                            string_value: ~x"./Value/StringValue/text()"os,
+                            binary_value: ~x"./Value/BinaryValue/text()"os,
+                            data_type: ~x"./Value/DataType/text()"s
                           ]
                         ])
-      fixed_attributes = case get_in(parsed_body, [:message, :attributes]) do
-                           nil ->
-                             parsed_body
 
-                             v when is_list(v) ->
-                             update_in(parsed_body, [:message, :attributes], &attribute_list_to_map/1)
-                         end
+      fixed_attributes = parsed_body
+      |> fix_attributes([:message, :attributes], &attribute_list_to_map/1)
+      |> fix_attributes([:message, :message_attributes], &message_attributes_to_map/1)
 
       {:ok, Map.put(resp, :body, fixed_attributes)}
     end
@@ -173,6 +177,55 @@ if Code.ensure_loaded?(SweetXml) do
                         request_id: request_id_xpath())
 
       {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
+    def message_attributes_to_map(list_of_message_attribtues) do
+      list_of_message_attribtues
+      |> Enum.reduce(%{}, fn(%{name: name, data_type: data_type} = attr, acc) ->
+        case parse_attribute_value(data_type, attr) do
+          ^attr ->
+            Map.put(acc, name, attr)
+          parsed ->
+            Map.put(acc, name, %{value: parsed, data_type: data_type})
+        end
+      end)
+    end
+
+    defp fix_attributes(parsed_body, attribute_path, fixup_fn) do
+      case get_in(parsed_body, attribute_path) do
+        nil ->
+          parsed_body
+
+        [] ->
+          parsed_body
+
+        v when is_list(v) ->
+          update_in(parsed_body, attribute_path, fixup_fn)
+      end
+    end
+
+    defp parse_attribute_value(<<"String", _rest :: binary>>, %{string_value: string_value}) do
+      string_value
+    end
+
+    defp parse_attribute_value(<<"Binary", _rest :: binary>>, %{binary_value: b64_encoded}) do
+      :base64.decode(b64_encoded)
+    end
+
+    defp parse_attribute_value(<<"Number", _rest :: binary>>, %{string_value: string_value}) do
+      try do
+        String.to_integer(string_value)
+      rescue ArgumentError ->
+          try do
+            String.to_float(string_value)
+          rescue ArgumentError ->
+              string_value
+          end
+      end
+    end
+
+    defp parse_attribute_value(_data_type, other) do
+      other
     end
 
     def attribute_list_to_map(list_of_maps, convert_to_atoms \\ false)

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -392,12 +392,12 @@ defmodule ExAws.SQS.ParserTest do
     message = response[:message]
     message_attributes = message[:message_attributes]
 
-    assert %{value: "good", data_type: "String"} == message_attributes["LiveAt"]
-    assert %{value: 382, data_type: "Number"} == message_attributes["NumberVal"]
-    assert %{value: <<3, 6, 9, 12>>, data_type: "Binary"} == message_attributes["BinaryVal"]
-    assert %{value: 382.03, data_type: "Number.float"} == message_attributes["FloatVal"]
-    assert %{value: <<2, 4, 6, 8, 10, 12>>, data_type: "Binary.gif"} == message_attributes["GifVal"]
-    assert %{value: "http://elixir-lang.org", data_type: "String.URL"} == message_attributes["UrlVal"]
+    assert %{value: "good", data_type: "String"} = message_attributes["LiveAt"]
+    assert %{value: 382, data_type: "Number"} = message_attributes["NumberVal"]
+    assert %{value: <<3, 6, 9, 12>>, data_type: "Binary"} = message_attributes["BinaryVal"]
+    assert %{value: 382.03, data_type: "Number.float"} = message_attributes["FloatVal"]
+    assert %{value: <<2, 4, 6, 8, 10, 12>>, data_type: "Binary.gif"} = message_attributes["GifVal"]
+    assert %{value: "http://elixir-lang.org", data_type: "String.URL"} = message_attributes["UrlVal"]
     assert %{string_value: "blarg", binary_value: "", data_type: "Unknown", name: "UnknownVal"} == message_attributes["UnknownVal"]
   end
 

--- a/test/lib/ex_aws/sqs_test.exs
+++ b/test/lib/ex_aws/sqs_test.exs
@@ -226,6 +226,17 @@ defmodule ExAws.SQSTest do
     assert expected == actual.params
   end
 
+  test "receive_message can set atom message attributes" do
+    expected = %{"Action" => "ReceiveMessage",
+                 "MessageAttributeName.1" => "FooAttr",
+                 "MessageAttributeName.2" => "BarAttr",
+                 "MessageAttributeName.3" => "BazAttr"}
+
+    actual = SQS.receive_message("12345/test_queue",
+                                 message_attribute_names: [:"FooAttr", :"BarAttr", :"BazAttr"])
+    assert expected == actual.params
+  end
+
   test "#delete_message" do
     expected = %{"Action" => "DeleteMessage", "ReceiptHandle" => "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="}
     assert expected == SQS.delete_message("982071696186/test_queue", "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw==").params

--- a/test/lib/ex_aws/sqs_test.exs
+++ b/test/lib/ex_aws/sqs_test.exs
@@ -200,6 +200,32 @@ defmodule ExAws.SQSTest do
                                                                       wait_timeout: 20).params
   end
 
+  test "#receive_message can set the message attributes to all" do
+    expected = %{"Action" => "ReceiveMessage", "MessageAttributeNames" => "All"}
+
+    actual = SQS.receive_message("12345/test_queue", message_attribute_names: :all)
+    assert expected == actual.params
+  end
+
+  test "#receive_message can specify message attributes" do
+    expected = %{"Action" => "ReceiveMessage",
+                 "MessageAttributeName.1" => "FooAttr",
+                 "MessageAttributeName.2" => "BarAttr",
+                 "MessageAttributeName.3" => "BazAttr"}
+
+    actual = SQS.receive_message("12345/test_queue",
+                                 message_attribute_names: ["FooAttr", "BarAttr", "BazAttr"])
+    assert expected == actual.params
+  end
+
+  test "#receive_message can specify wildcard attributes" do
+    expected = %{"Action" => "ReceiveMessage",
+                 "MessageAttributeName.1" => "Foo.*"}
+    actual = SQS.receive_message("12345/test_queue",
+                                 message_attribute_names: ["Foo.*"])
+    assert expected == actual.params
+  end
+
   test "#delete_message" do
     expected = %{"Action" => "DeleteMessage", "ReceiptHandle" => "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw=="}
     assert expected == SQS.delete_message("982071696186/test_queue", "AQEB0aw+z96sMOUWLQuIzA7nPHS7zUOIRlV0OEqvDoKtNcHxSVDQEfY0gBOJKGcnyTvIUncpimPv0CfQDFbwmdU9E00793cP19Bx8BqzuS0sNrARyY4M4xVi7ceVYHMSNU1uyF/+sK6u8yAGnsbsgmPg4AUs5oapv5Qawiq5HJGgH3cmRPy5/IW+b9W6HVy//uNzejbIcAjQX58Dd79D4AGb9Iu4dqfEVK7zo5BCTy+pz9hqGf5MT3jkrd5umjwGdrg3sVBYhrLjmgaqftON8JclkmrUJk0LzPwQ4DdpT8oz5mh7VzAjRXkIA0IQ8PGFFGPMIb8gWNzJ4KA4/OYlnDYyGw==").params


### PR DESCRIPTION
SQS has the concept of Attributes *and* MessageAttributes. Attributes
are intrinsic to a message, and are set by the system.
MessageAttributes, however are set by the user and can be
anything.

This PR adds support for getting and setting message attributes, and can
parse numeric, binary and string attributes.

@benwilson512 