### PR TITLE
Handled multiple messages from receive_message

### DIFF
--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -127,17 +127,9 @@ if Code.ensure_loaded?(SweetXml) do
         |> fix_attributes([:message_attributes], &message_attributes_to_map/1)
       end)
 
-      fixed_attributes = case new_messages do
-                           [message] ->
-                             parsed_body
-                             |> Map.put(:message, message)
-                             |> Map.delete(:messages)
+      parsed_body = Map.put(parsed_body, :messages, new_messages)
 
-                           messages ->
-                             Map.put(parsed_body, :messages, messages)
-                         end
-
-      {:ok, Map.put(resp, :body, fixed_attributes)}
+      {:ok, Map.put(resp, :body, parsed_body)}
     end
 
     def parse({:ok, %{body: xml}=resp}, :send_message) do

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -120,7 +120,7 @@ if Code.ensure_loaded?(SweetXml) do
                         ])
 
       new_messages = parsed_body
-      |> Map.get(:messages)
+      |> Map.get(:messages, [])
       |> Enum.map(fn(message) ->
         message
         |> fix_attributes([:attributes], &attribute_list_to_map/1)

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -363,6 +363,7 @@ defmodule ExAws.SQS.ParserTest do
     {:ok, %{body: response}} = Parsers.parse(rsp, :receive_message)
 
     assert "fcd6512a-5746-5803-b2d7-014dfd07f23a" == response[:request_id]
+    assert [] == response[:messages]
   end
 
   test "it should handle parsing a message with custom attributes" do

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -299,6 +299,55 @@ defmodule ExAws.SQS.ParserTest do
     assert 1250700979248 == attributes["approximate_first_receive_timestamp"]
   end
 
+  test "parsing a receive message response with multiple messages" do
+    rsp = """
+    <?xml version=\"1.0\"?>
+    <ReceiveMessageResponse xmlns=\"http://queue.amazonaws.com/doc/2012-11-05/\">
+      <ReceiveMessageResult>
+        <Message>
+          <MessageId>70723100-7a9e-474c-9342-4a07b5d3bcff</MessageId>
+          <ReceiptHandle>AQEB1vSE6FNrf7oYptJYdkVMvdx1bO6ysaovI++YzylE2GoFH9kXAfnThwfy8wXGjl0XXEx3v7jh3bv353AL3+ODUYSY5vDAr2Xi1JqS96gU/MppM1et/dPYBYQcMUC9a/0GMojJ4AKAfxqYnov9VLzzi5zAgQIxnHp/hB3s30ZP7NaIsOe4d3rXWDwavmqwR/pfl+3krPUhiGwlTaETQkmkmE2KN/iD0X/NPNhxeFho7EHR9tCHK9mzbsdbwbRpRI4ZYfVDzzTx6kjZO9qeEKetL8XZ1InXEhQwqqv96Vvm3gIZJM+2if46WcZQexVT7GiMjIxNkXJjoCaGfAojxf1KAnIseZQZGTJpbt5NqfXPBJBThCJ4ocCt8lRm7qS25fVLHgr1dnQGE032uLpzXc04ti2MXTdBYkJlq285pyCi1wI=</ReceiptHandle>
+          <MD5OfBody>68ee3fbec6195f397d7f696599dd278a</MD5OfBody>
+          <Body>Message 1</Body>
+          <MessageAttribute>
+            <Name>SequenceId</Name>
+              <Value>
+                <StringValue>first</StringValue>
+                <DataType>String</DataType>
+              </Value>
+            </MessageAttribute>
+          </Message>
+          <Message>
+            <MessageId>685b3199-2350-476e-a9b4-b9357597c5f9</MessageId>
+            <ReceiptHandle>AQEBnaNIuXS7t7/+QgcF8e7aD83Is8Q3+jPTLK6Rb7qkZYs50EhaR4JAjNeMrWT4viwwoK4ziWNMGZaZfmIHUS667Pua3yOFC2nKRi5ZnOPxGFfRo/ilVb8kuPQmcoDLFAGwQA5hjVlKwNd3YvfXtYZsJwiMEEbbKqwYhJD1bTxMbMesorO8WtU7kqrlTghS3P7Ze6YD3ESivzVDsghA+wRavj17HGtRSudc5kkCgPhorLQNeVBLtticW2BpqF2+wclv8fB+JtCU6s0nSE/LbqQppj8xrX1MzqdMIcYpTrQ4CGdjZ9JZwv+3yG3H5l31w9zwxced7VuJQ3854I0dHk43Jq1+iaCBKTynRumYgWAViSafeR/V3wIzIfpFsnHVmo5GWtOJVgNWHQLBJ0LocHQZ2vj4JH/hewhhyzdt3jKQ1eA=</ReceiptHandle>
+            <MD5OfBody>47f79c924409f444efd458d9976becb5</MD5OfBody>
+            <Body>Message 2</Body>
+            <MessageAttribute>
+              <Name>SequenceId</Name>
+              <Value>
+                <StringValue>second</StringValue>
+                <DataType>String</DataType>
+              </Value>
+            </MessageAttribute>
+          </Message>
+        </ReceiveMessageResult>
+      <ResponseMetadata>
+        <RequestId>e74a318e-f911-56da-8302-61e0baee07ae</RequestId>
+      </ResponseMetadata>
+    </ReceiveMessageResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: response}} = Parsers.parse(rsp, :receive_message)
+    [message_1, message_2] = response[:messages]
+
+    assert "Message 1" == message_1.body
+    assert %{value: "first"}  = message_1.message_attributes["SequenceId"]
+
+    assert "Message 2" == message_2.body
+    assert %{value: "second"}  = message_2.message_attributes["SequenceId"]
+  end
+
   test "parsing an empty receive message response" do
     rsp = """
     <?xml version=\"1.0\"?>

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -282,7 +282,7 @@ defmodule ExAws.SQS.ParserTest do
     |> to_success
 
     {:ok, %{body: response}} = Parsers.parse(rsp, :receive_message)
-    message = response[:message]
+    [message] = response[:messages]
 
     handle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="
 
@@ -438,7 +438,7 @@ defmodule ExAws.SQS.ParserTest do
     """
     |> to_success
     {:ok, %{body: response}} = Parsers.parse(rsp, :receive_message)
-    message = response[:message]
+    [message] = response[:messages]
     message_attributes = message[:message_attributes]
 
     assert %{value: "good", data_type: "String"} = message_attributes["LiveAt"]


### PR DESCRIPTION
If multiple messages are requested, the response contains the key
`:messages`, which contains a list of the messages. If one is requested,
the response contains the `:message` key.

@benwilson512, I'm not sure how I feel about changing the key based on the number of messages returned. Thoughts appreciated. 