### PR TITLE
Fixed error parsing

### DIFF
--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -157,7 +157,7 @@ if Code.ensure_loaded?(SweetXml) do
       parse_request_id(resp, ~x"//SetQueueAttributesResponse")
     end
 
-    def parse({:error, {type, http_status_code, xml}}, _) do
+    def parse({:error, {type, http_status_code, %{body: xml}}}, _) do
       parsed_body = xml
       |> SweetXml.xpath(~x"//ErrorResponse",
                         request_id: ~x"./RequestId/text()"s,

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -8,7 +8,7 @@ defmodule ExAws.SQS.ParserTest do
   end
 
   def to_error(doc) do
-    {:error, {:http_error, 403, doc}}
+    {:error, {:http_error, 403, %{body: doc}}}
   end
 
   test "#parsing a list queue response" do


### PR DESCRIPTION
Something changed and caused the error shape to change, which broke the
error parsers.

We should figure out how to prevent regressions like this in the future.
@benwilson512  