### PR TITLE
Add S3.presigned_post to generate form data for browser uploads

### DIFF
--- a/lib/ex_aws/auth/presigned_posts.ex
+++ b/lib/ex_aws/auth/presigned_posts.ex
@@ -1,0 +1,41 @@
+defmodule ExAws.Auth.PresignedPosts do
+  @moduledoc false
+
+  import ExAws.Auth.Utils
+  alias ExAws.Auth.Credentials
+  alias ExAws.Auth.PresignedPosts.PresignedPost
+
+  def generate_presigned_post(config, bucket_name, key, opts \\ []) do
+    datetime = Keyword.get(opts, :current_datetime, :calendar.universal_time)
+    expires_in = Keyword.get(opts, :expires_in, 60 * 60) #seconds
+    additional_fields = Keyword.get(opts, :fields, [])
+
+    expiration = ExAws.Utils.add_seconds(datetime, expires_in)
+    credential = Credentials.generate_credential_v4("s3", config, datetime)
+
+    presigned_post =
+      PresignedPost.new
+      |> PresignedPost.set_expiration(expiration)
+      |> PresignedPost.set_bucket(bucket_name)
+      |> PresignedPost.put_field("key", key)
+      |> PresignedPost.put_field("x-amz-algorithm", "AWS4-HMAC-SHA256")
+      |> PresignedPost.put_field("x-amz-credential", credential)
+      |> PresignedPost.put_field("x-amz-date", amz_date(datetime))
+      |> add_additional_fields(additional_fields)
+
+    %{
+      url: base_url(config, bucket_name),
+      form_fields: PresignedPost.fields_with_signature(presigned_post, config, datetime)
+    }
+  end
+
+  defp add_additional_fields(presigned_post, additional_fields) do
+    Enum.reduce(additional_fields, presigned_post, fn({field, value}, acc) ->
+      PresignedPost.put_field(acc, field, value)
+    end)
+  end
+
+  defp base_url(config, bucket_name) do
+    "#{config.scheme}#{bucket_name}.#{config.host}"
+  end
+end

--- a/lib/ex_aws/auth/presigned_posts/policy.ex
+++ b/lib/ex_aws/auth/presigned_posts/policy.ex
@@ -1,0 +1,34 @@
+defmodule ExAws.Auth.PresignedPosts.Policy do
+  @moduledoc false
+  import ExAws.Auth.Utils
+
+  defstruct [expiration: nil, conditions: []]
+
+  def new do
+    %__MODULE__{}
+  end
+
+  def set_expiration(policy, datetime) do
+    %__MODULE__{policy | expiration: datetime}
+  end
+
+  def add_condition(policy = %__MODULE__{conditions: conditions}, condition) do
+    new_conditions =
+      conditions
+      |> Enum.reverse
+      |> List.insert_at(0, condition)
+      |> Enum.reverse
+    %__MODULE__{policy | conditions: new_conditions}
+  end
+
+  def encode(policy = %__MODULE__{}, config) do
+    policy |> to_map |> config.json_codec.encode! |> Base.encode64
+  end
+
+  defp to_map(policy = %__MODULE__{}) do
+    %{
+      "expiration" => iso_8601_format(policy.expiration),
+      "conditions" => policy.conditions
+    }
+  end
+end

--- a/lib/ex_aws/auth/presigned_posts/presigned_post.ex
+++ b/lib/ex_aws/auth/presigned_posts/presigned_post.ex
@@ -1,0 +1,63 @@
+defmodule ExAws.Auth.PresignedPosts.PresignedPost do
+  @moduledoc false
+  alias ExAws.Auth.PresignedPosts.Policy
+  alias ExAws.Auth.Signatures
+
+  @doc """
+  Creates a new PresignedPost struct with a pre-initialized policy
+  """
+  def new do
+    %{fields: %{}, policy: Policy.new }
+  end
+
+  @doc """
+  Set the expiration datetime of this policy
+  """
+  def set_expiration(%{policy: policy} = presigned_post, datetime) do
+    %{presigned_post | policy: Policy.set_expiration(policy, datetime)}
+  end
+
+  @doc """
+  Adds a field to the presigned post
+  """
+  def put_field(%{fields: fields} = presigned_post, "key", value) do
+    fields = Map.put(fields, "key", value)
+
+    %{presigned_post | fields: fields}
+    |> put_policy_condition(["starts-with", "$key", "#{Path.dirname(value)}/"])
+  end
+  def put_field(%{fields: fields} = presigned_post, field_name, value) do
+    fields = Map.put(fields, field_name, value)
+
+    %{presigned_post | fields: fields}
+    |> put_policy_condition(%{field_name => value})
+  end
+
+  @doc """
+  Adds a condition to the presigned post's policy
+  """
+  def put_policy_condition(%{policy: policy} = presigned_post, condition) do
+    policy = Policy.add_condition(policy, condition)
+    %{presigned_post | policy: policy}
+  end
+
+  @doc """
+  Sets the bucket for a presigned post
+  """
+  def set_bucket(presigned_post, bucket_name) do
+    put_policy_condition(presigned_post, %{"bucket" => bucket_name})
+  end
+
+  @doc """
+  Returns all of the post fields
+  """
+  def fields_with_signature(presigned_post, config, datetime) do
+    encoded_policy = Policy.encode(presigned_post.policy, config)
+    signature = Signatures.generate_signature_v4(
+      "s3", config, datetime, encoded_policy)
+
+    presigned_post.fields
+    |> Map.put("policy", encoded_policy)
+    |> Map.put("x-amz-signature", signature)
+  end
+end

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -57,6 +57,13 @@ defmodule ExAws.Auth.Utils do
     |> Enum.map(&zero_pad/1)
   end
 
+  def iso_8601_format({{year, month, date}, {hour, min, sec}}) do
+    "~.4.0w-~.2.0w-~.2.0wT~.2.0w:~.2.0w:~.2.0wZ"
+    |> :io_lib.format([year, month, date, hour, min, sec])
+    |> IO.iodata_to_binary
+  end
+  def iso_8601_format(nil), do: nil
+
   defp zero_pad(<<_>> = val), do: "0" <> val
   defp zero_pad(val), do: val
 end

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -889,6 +889,72 @@ defmodule ExAws.S3 do
     end
   end
 
+  @type presigned_post_opts :: [
+    {:expires_in, pos_integer()}
+    | {:current_datetime, :calendar.datetime}
+    | {:fields, [{String.t, String.t}]}
+  ]
+  @type presigned_post_response :: %{
+    url: String.t,
+    form_fields: %{optional(String.t) => String.t}
+  }
+
+  @doc """
+  Generates a presigned POST request that can be used for uploading an object.
+
+  This generates a presigned post request that can be used by the browser to
+  directly upload an object to s3. Given the following request,
+
+  ```
+  response = S3.presigned_post(config, "my-bucket", "path/to/my/file.txt")
+  ```
+
+  the browser must send a POST request with enctype of `multipart/form-data` to `response.url`.
+  This request should have `response.form_fields` as its body, plus an additional field
+  named `file` which contains the contents of the file to be uploaded.
+
+  ## Options
+
+  * `fields`: Additional form fields to be signed and included in request.
+  * `expires_in`: Number of seconds until this presigned post expires. Defaults to 1 hour.
+  * `current_datetime`: Allows overriding the datetime that the request is signed.
+     Defaults to the current datetime.
+
+  ## Examples
+
+  ```
+  # Presigned post with no additional fields
+  S3.presigned_post(config, "my-bucket", "path/to/my/file.txt")
+
+  # Presigned post with acl and content-type preset
+  S3.presigned_post(
+    config,
+    "my-bucket",
+    "path/to/my/file.txt",
+    fields: [%{"acl" => "public-read"}, %{"content-type" => "text/plain"}]
+    )
+
+  # Presigned post where original filename is kept intact.
+  S3.presigned_post(config, "my-bucket", "path/to/my/${filename}")
+
+  # Presigned post that expires in 5 minutes
+  S3.presigned_post(config, "my-bucket", "path/to/my/file.txt", expires_in: 60 * 5)
+  ```
+
+  For more information, see http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html
+  """
+  @spec presigned_post(
+    config :: %{},
+    bucket_name :: String.t,
+    key :: String.t,
+    opts :: presigned_post_opts) :: presigned_post_response
+  def presigned_post(config, bucket_name, key, opts \\ []) do
+    presigned_post = ExAws.Auth.PresignedPosts.generate_presigned_post(
+      config, bucket_name, key, opts)
+
+    presigned_post
+  end
+
   defp url_to_sign(bucket, object, config, virtual_host) do
     object = ensure_slash(object)
     case virtual_host do

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -100,4 +100,11 @@ defmodule ExAws.Utils do
 
     greg_secs - @seconds_0_to_1970
   end
+
+  def add_seconds(datetime, seconds_to_add) do
+    datetime
+    |> :calendar.datetime_to_gregorian_seconds()
+    |> Kernel.+(seconds_to_add)
+    |> :calendar.gregorian_seconds_to_datetime()
+  end
 end

--- a/test/lib/ex_aws/auth/presigned_posts/policy_test.exs
+++ b/test/lib/ex_aws/auth/presigned_posts/policy_test.exs
@@ -1,0 +1,67 @@
+defmodule ExAws.Auth.PresignedPosts.PolicyTest do
+  use ExUnit.Case, async: true
+
+  alias ExAws.Auth.PresignedPosts.Policy
+
+  describe "add_condition/2" do
+    test "adding multiple entries retains order" do
+      policy =
+        Policy.new
+        |> Policy.add_condition(%{"acl" => "public-read"})
+        |> Policy.add_condition(["starts_with", "$key", "something/"])
+        |> Policy.add_condition(%{"Content-Type" => "image/jpeg"})
+
+      assert policy.conditions == [
+        %{"acl" => "public-read"},
+        ["starts_with", "$key", "something/"],
+        %{"Content-Type" => "image/jpeg"},
+      ]
+    end
+  end
+
+  describe "encode/2" do
+    test "encoding a policy with an expiration" do
+      config = build_config()
+      datetime = {{2016,8,29},{19,41,33}}
+
+      policy =
+        Policy.new
+        |> Policy.set_expiration(datetime)
+        |> Policy.add_condition(%{"acl" => "public-read"})
+
+      encoded_policy = Policy.encode(policy, config)
+
+      assert decode_policy(encoded_policy, config) == %{
+        "expiration" => "2016-08-29T19:41:33Z",
+        "conditions" => [%{"acl" => "public-read"}]
+      }
+    end
+
+    test "encoding a policy without an expiration" do
+      config = build_config()
+
+      policy =
+        Policy.new
+        |> Policy.add_condition(%{"acl" => "public-read"})
+
+        encoded_policy = Policy.encode(policy, config)
+
+      assert decode_policy(encoded_policy, config) == %{
+        "expiration" => nil,
+        "conditions" => [%{"acl" => "public-read"}]
+      }
+    end
+
+    defp decode_policy(encoded_policy, config) do
+      encoded_policy |> Base.decode64! |> config.json_codec.decode!
+    end
+
+    defp build_config() do
+      ExAws.Config.new(:s3, [
+        access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1"
+      ])
+    end
+  end
+end

--- a/test/lib/ex_aws/auth/presigned_posts/presigned_post_test.exs
+++ b/test/lib/ex_aws/auth/presigned_posts/presigned_post_test.exs
@@ -1,0 +1,88 @@
+defmodule ExAws.Auth.PresignedPosts.PresignedPostTest do
+  use ExUnit.Case, async: true
+
+  alias ExAws.Auth.PresignedPosts.{Policy, PresignedPost}
+  alias ExAws.Auth.Signatures
+
+  describe "put_field/3" do
+    test "adding a generic field" do
+      presigned_post =
+        PresignedPost.new
+        |> PresignedPost.put_field("content-type", "application/json")
+
+      assert %{"content-type" => "application/json"} = presigned_post.fields
+      assert %{"content-type" => "application/json"} in presigned_post.policy.conditions
+    end
+
+    test "adding key field" do
+      presigned_post =
+        PresignedPost.new
+        |> PresignedPost.put_field("key", "uploads/${filename}")
+
+      assert %{"key" => "uploads/${filename}"} = presigned_post.fields
+      assert ["starts-with", "$key", "uploads/"] in presigned_post.policy.conditions
+    end
+  end
+
+  describe "put_policy_condition/2" do
+    test "adds a condition to the policy" do
+      condition = ["starts-with", "$content-type", "image/"]
+
+      presigned_post =
+        PresignedPost.new
+        |> PresignedPost.put_policy_condition(condition)
+
+      assert condition in presigned_post.policy.conditions
+    end
+  end
+
+  describe "set_bucket/2" do
+    test "adds a bucket condition to the policy" do
+      presigned_post =
+        PresignedPost.new
+        |> PresignedPost.set_bucket("my-test-bucket")
+
+      assert %{"bucket" => "my-test-bucket"} in presigned_post.policy.conditions
+    end
+  end
+
+  describe "set_expiration/2" do
+    test "setting the expiration on the policy" do
+      datetime = {{2016,8,29},{19,41,33}}
+
+      presigned_post =
+        PresignedPost.new
+        |> PresignedPost.set_expiration(datetime)
+
+      assert presigned_post.policy.expiration == datetime
+    end
+  end
+
+  describe "fields_with_signature/2" do
+    test "with a basic presigned post" do
+      config = ExAws.Config.new(:s3, [
+        access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1"
+      ])
+      datetime = {{2016,8,29},{19,41,33}}
+
+      presigned_post =
+        PresignedPost.new()
+        |> PresignedPost.set_expiration(datetime)
+        |> PresignedPost.put_field("content-type", "application/json")
+
+      fields = PresignedPost.fields_with_signature(presigned_post, config, datetime)
+
+      expected_policy = Policy.encode(presigned_post.policy, config)
+      expected_signature = Signatures.generate_signature_v4(
+        "s3", config, datetime, expected_policy)
+
+      assert fields == %{
+        "content-type" => "application/json",
+        "policy" => expected_policy,
+        "x-amz-signature" =>  expected_signature
+      }
+    end
+  end
+end

--- a/test/lib/ex_aws/auth/presigned_posts_test.exs
+++ b/test/lib/ex_aws/auth/presigned_posts_test.exs
@@ -1,0 +1,105 @@
+defmodule ExAws.Auth.PresignedPostsTest do
+  use ExUnit.Case, async: true
+
+  import ExAws.Auth.Utils
+  alias ExAws.Auth.{Credentials, PresignedPosts, Signatures}
+  alias ExAws.Auth.PresignedPosts.{Policy, PresignedPost}
+
+  describe "generate_presigned_post/4" do
+    test "integration test to ensure the post is generated correctly" do
+      config = build_config
+      bucket_name = "my-test-bucket"
+      key = "my-test-folder/${filename}"
+      datetime = {{2016,8,29},{19,41,33}}
+
+      expected_policy =
+        Policy.new
+        |> Policy.set_expiration(datetime |> ExAws.Utils.add_seconds(3600))
+        |> Policy.add_condition(%{"bucket" => bucket_name})
+        |> Policy.add_condition(["starts-with", "$key", "my-test-folder/"])
+        |> Policy.add_condition(%{"x-amz-algorithm" => "AWS4-HMAC-SHA256"})
+        |> Policy.add_condition(%{"x-amz-credential" => Credentials.generate_credential_v4("s3", config, datetime)})
+        |> Policy.add_condition(%{"x-amz-date" => amz_date(datetime)})
+        |> Policy.add_condition(%{"content-type" => "application/json"})
+        |> Policy.add_condition(%{"acl" => "public-read"})
+        |> Policy.encode(config)
+
+      result = PresignedPosts.generate_presigned_post(
+        config,
+        bucket_name,
+        key,
+        fields: [{"content-type", "application/json"},{"acl", "public-read"}],
+        current_datetime: datetime)
+
+      assert result == %{
+        url: "#{config.scheme}#{bucket_name}.#{config.host}",
+        form_fields: %{
+          "key" => key,
+          "x-amz-date" => amz_date(datetime),
+          "x-amz-algorithm" => "AWS4-HMAC-SHA256",
+          "x-amz-credential" => Credentials.generate_credential_v4("s3", config, datetime),
+          "x-amz-signature" =>  Signatures.generate_signature_v4("s3", config, datetime, expected_policy),
+          "content-type" => "application/json",
+          "acl" => "public-read",
+          "policy" => expected_policy,
+        }
+      }
+    end
+
+    test "generates the correct form fields with default options" do
+      config = build_config()
+      bucket_name = "my-test-bucket"
+      key = "my-test-folder/${filename}"
+      datetime = {{2016,8,29},{19,41,33}}
+
+      result = PresignedPosts.generate_presigned_post(
+        config,
+        bucket_name,
+        key,
+        current_datetime: datetime)
+
+      expected_presigned_post =
+        PresignedPost.new
+        |> PresignedPost.set_expiration(datetime |> ExAws.Utils.add_seconds(3600))
+        |> PresignedPost.set_bucket(bucket_name)
+        |> PresignedPost.put_field("key", key)
+        |> PresignedPost.put_field("x-amz-algorithm", "AWS4-HMAC-SHA256")
+        |> PresignedPost.put_field(
+            "x-amz-credential", Credentials.generate_credential_v4("s3", config, datetime))
+        |> PresignedPost.put_field("x-amz-date", amz_date(datetime))
+
+      assert result.form_fields ==
+        PresignedPost.fields_with_signature(expected_presigned_post, config, datetime)
+    end
+
+    test "returns the correct url for a us-west-2 bucket" do
+      config = build_config(region: "us-west-2", host: "s3-us-west-2.amazonaws.com")
+      bucket_name = "my-test-bucket"
+      key = "my-test-folder/${filename}"
+
+      result = PresignedPosts.generate_presigned_post(config, bucket_name, key)
+
+      assert result.url == "https://my-test-bucket.s3-us-west-2.amazonaws.com"
+    end
+
+    test "returns the correct url for a us-east-1 bucket" do
+      config = build_config(region: "us-east-1")
+      bucket_name = "my-test-bucket"
+      key = "my-test-folder/${filename}"
+
+      result = PresignedPosts.generate_presigned_post(config, bucket_name, key)
+
+      assert result.url == "https://my-test-bucket.s3.amazonaws.com"
+    end
+  end
+
+  defp build_config(opts \\ []) do
+    defaults = [
+      access_key_id: "AKIAIOSFODNN7EXAMPLE",
+      secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1"
+    ]
+
+    ExAws.Config.new(:s3, Keyword.merge(defaults, opts))
+  end
+end

--- a/test/lib/ex_aws/auth/utils_test.exs
+++ b/test/lib/ex_aws/auth/utils_test.exs
@@ -12,4 +12,8 @@ defmodule ExAws.Auth.UtilsTest do
     assert amz_date({{2015, 11, 22}, {11, 31, 51}}) == "20151122T113151Z"
   end
 
+  test "iso_8601_format/1" do
+    assert iso_8601_format({{2015, 1, 2}, {1, 3, 5}}) == "2015-01-02T01:03:05Z"
+    assert iso_8601_format(nil) == nil
+  end
 end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -148,6 +148,17 @@ defmodule ExAws.S3Test do
     assert "expires_in_exceeds_one_week" == reason
   end
 
+  test "#presigned_post returns PresignedPosts.generate_presigned_post" do
+    config = config()
+    bucket_name = "test_bucket"
+    key = "test_uploads/${filename}"
+
+    presigned_post = S3.presigned_post(config, bucket_name, key)
+
+    assert presigned_post == ExAws.Auth.PresignedPosts.generate_presigned_post(
+      config, bucket_name, key)
+  end
+
   defp assert_pre_signed_url(url, expected_scheme_host_path, expected_expire) do
     uri = URI.parse(url)
     assert expected_scheme_host_path == "#{uri.scheme}://#{uri.host}#{uri.path}"

--- a/test/lib/ex_aws/utils_test.exs
+++ b/test/lib/ex_aws/utils_test.exs
@@ -28,4 +28,8 @@ defmodule ExAws.UtilsTest do
   test "iso_z_to_secs/1" do
     assert iso_z_to_secs("2015-07-05T22:16:18Z") == 1436134578
   end
+
+  test "add_seconds/2" do
+    assert add_seconds({{2016, 8, 29}, {22, 31, 19}}, 10) == {{2016, 8, 29}, {22, 31, 29}}
+  end
 end


### PR DESCRIPTION
This adds the ability to generate presigned post api for direct browser uploads to S3. This is similar to using presigned urls, but it uses a different api and allows you to use keys like "folder/${filename}" where ${filename} is replaced by S3 based on the name of the file that is uploaded.

Here are the docs for the API I am using: http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html

Let me know what you think.
