### PR TITLE
Use ini file configuration without session token

### DIFF
--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -40,9 +40,13 @@ if Code.ensure_loaded?(ConfigParser) do
     def replace_token_key(credentials) do
       token = Map.get(credentials, :session_token)
 
-      credentials
-      |> Map.delete(:session_token)
-      |> Map.put(:security_token, token)
+      if token do
+        credentials
+        |> Map.delete(:session_token)
+        |> Map.put(:security_token, token)
+      else
+        credentials
+      end
     end
   end
 else


### PR DESCRIPTION
Thanks to [this pull request](https://github.com/CargoSense/ex_aws/pull/245)  for use ini file configuration.

aws cli configuration without session token cannot use this feature.

For example, profile without session token(we use this when simply change account)

```
[profile]
aws_access_key_id=yourawsaccesskey
aws_secret_access_key=yourawssecretaccesskey
```

This pull request is a change to enable load ini file configuration without session token.