### PR TITLE
Added support for ECS task role credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,16 @@ ExAws has by default the equivalent including the following in your mix.exs
 
 ```elixir
 config :ex_aws,
-  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
-  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
+  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role],
+  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, {:awscli, "default", 30}, :instance_role],
 ```
 
-This means it will first look for the AWS standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables, and fall back using instance meta-data if those don't exist. You should set those environment variables to your credentials, or configure an instance that this library runs on to have an iam role.
+This means it will try to resolve credentials in order
+* Look for the AWS standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+* Try to load the awscli files `~/.aws/config` and `~/.aws/credentials` and use the `default` profile
+* Resolve credentials with IAM
+  * If running inside ECS and a [task role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) has been assigned it will use it
+  * Otherwise it will fall back to the [instance role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 
 ## Retries
 

--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -8,19 +8,38 @@ defmodule ExAws.InstanceMeta do
   # AWS InstanceMetaData URL
   @meta_path_root "http://169.254.169.254/latest/meta-data/"
 
-  def request(config, path) do
-    case config.http_client.request(:get, @meta_path_root <> path) do
+  # Endpoint for ECS taks role credentials
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+  @task_role_root "http://169.254.170.2"
+
+  def request(config, url) do
+    case config.http_client.request(:get, url) do
       {:ok, %{body: body}} -> body
     end
   end
 
-  def role(config) do
+  def instance_role(config) do
     ExAws.InstanceMeta.request(config, "/iam/security-credentials/")
   end
 
-  def security_credentials(config) do
-    result = ExAws.InstanceMeta.request(config, "/iam/security-credentials/#{role(config)}")
+  def task_role_credentials(config) do
+    case System.get_env("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") do
+      nil -> nil
+      uri -> ExAws.InstanceMeta.request(config, @task_role_root <> uri)
+             |> config.json_codec.decode!
+    end
+  end
+
+  def instance_role_credentials(config) do
+    ExAws.InstanceMeta.request(config, @meta_path_root <> "/iam/security-credentials/#{instance_role(config)}")
     |> config.json_codec.decode!
+  end
+
+  def security_credentials(config) do
+    result = case task_role_credentials(config) do
+	       nil -> instance_role_credentials(config)
+	       credentials -> credentials
+	     end
 
     %{
       access_key_id: result["AccessKeyId"],


### PR DESCRIPTION
Hi,

I've added support for looking up task role credentials when using ECS (taskRoleArn in the task definition) which overwrites the instance role.

Thanks