### PR TITLE
Dynamo streams implementation

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -12,6 +12,12 @@ config :ex_aws, :dynamodb,
   port: 8000,
   region: "us-east-1"
 
+config :ex_aws, :dynamodb_streams,
+  scheme: "http://",
+  host: "localhost",
+  port: 8000,
+  region: "us-east-1"
+
 config :ex_aws, :rds,
   scheme: "https://",
   host: {"$region", "rds.$region.amazonaws.com"},

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,12 @@ config :ex_aws, :dynamodb,
   port: 8000,
   region: "us-east-1"
 
+config :ex_aws, :dynamodb_streams,
+  scheme: "http://",
+  host: "localhost",
+  port: 8000,
+  region: "us-east-1"
+
 config :ex_aws, :lambda,
   host: "lambda.us-east-1.amazonaws.com",
   scheme: "https://",

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -20,7 +20,7 @@ defmodule ExAws.Auth do
       url,
       headers,
       body,
-      service |> service_name,
+      service |> service_override(config) |> service_name,
       datetime,
       config)
 
@@ -181,6 +181,14 @@ defmodule ExAws.Auth do
       [{"X-Amz-Security-Token", config[:security_token]}]
     else
       []
+    end
+  end
+
+  defp service_override(service, config) do
+    if config[:service_override] do
+      config[:service_override]
+    else
+      service
     end
   end
 end

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -34,6 +34,13 @@ defmodule ExAws.Config.Defaults do
       region: "us-east-1",
       port: 80
     },
+    dynamodb_streams: %{
+      scheme: "https://",
+      host: {"$region", "streams.dynamodb.$region.amazonaws.com"},
+      region: "us-east-1",
+      port: 80,
+      service_override: :dynamodb
+    },
     lambda: %{
       host: {"$region", "lambda.$region.amazonaws.com"},
       scheme: "https://",

--- a/lib/ex_aws/dynamo_streams.ex
+++ b/lib/ex_aws/dynamo_streams.ex
@@ -1,0 +1,125 @@
+defmodule ExAws.DynamoStreams do
+  @moduledoc """
+  Operations on DynamoDB Streams
+
+  http://docs.aws.amazon.com/dynamodbstreams/latest/APIReference/API_Operations.html
+
+  NOTE: When Mix.env in [:test, :dev] dynamo clients will run by default against
+  Dynamodb local.
+
+  Enabling/Disabling streams on a table is performed through the `Dynamo.update_table` operation.
+  The stream arn can then be retrieved with `Dynamo.describe_table` in the `LatestStreamArn` key.
+
+  """
+
+  import ExAws.Utils, only: [camelize_keys: 1, upcase: 1]
+  require Logger
+
+  @namespace "DynamoDBStreams_20120810"
+
+  ## Streams
+  ######################
+
+  @type stream_arn :: binary
+
+  @doc """
+  Lists all of the streams associated with an account.
+  If you have multiple streams on a table (created by disabling/enabling the stream)
+  you may have difficulty identifying the active stream from this operation.
+  """
+  @type list_stream_opts :: [
+    {:limit, pos_integer} |
+    {:exclusive_start_stream_arn, binary} |
+    {:table_name, binary}
+  ]
+  @spec list_streams() :: ExAws.Operation.JSON.t
+  @spec list_streams(opts :: list_stream_opts) :: ExAws.Operation.JSON.t
+  def list_streams(opts \\ []) do
+    data = opts
+    |> camelize_keys
+    request(:list_streams, data)
+  end
+
+  @doc "Describe Stream"
+  @type describe_stream_opts :: [
+    {:limit, pos_integer} |
+    {:exclusive_start_shard_id, binary}
+  ]
+  @spec describe_stream(stream_arn :: stream_arn) :: ExAws.Operation.JSON.t
+  @spec describe_stream(stream_arn :: stream_arn, opts :: describe_stream_opts) :: ExAws.Operation.JSON.t
+  def describe_stream(stream_arn, opts \\ []) do
+    data = opts
+    |> camelize_keys
+    |> Map.merge(%{"StreamArn" => stream_arn})
+    request(:describe_stream, data)
+  end
+
+  ## Records
+  ######################
+
+  @doc "Get stream records"
+  @type get_records_opts :: [
+    {:limit, pos_integer}
+  ]
+  @spec get_records(shard_iterator :: binary) :: ExAws.Operation.JSON.t
+  @spec get_records(shard_iterator :: binary, opts :: get_records_opts) :: ExAws.Operation.JSON.t
+  def get_records(shard_iterator, opts \\ []) do
+    data = opts
+    |> camelize_keys
+    |> Map.merge(%{"ShardIterator" => shard_iterator})
+
+    request(:get_records, data)
+  end
+
+  ## Shards
+  ######################
+
+  @doc """
+  Get a shard iterator
+  """
+  @type shard_iterator_types ::
+    :at_sequence_number |
+    :after_sequence_number |
+    :trim_horizon |
+    :latest
+  @type get_shard_iterator_opts :: [
+    {:sequence_number, binary}
+  ]
+  @spec get_shard_iterator(
+    stream_arn :: stream_arn,
+    shard_id :: binary,
+    shard_iterator_type :: shard_iterator_types) :: ExAws.Operation.JSON.t
+  @spec get_shard_iterator(
+    stream_arn :: stream_arn,
+    shard_id :: binary,
+    shard_iterator_type :: shard_iterator_types,
+    opts :: get_shard_iterator_opts) :: ExAws.Operation.JSON.t
+  def get_shard_iterator(stream_arn, shard_id, shard_iterator_type, opts \\ []) do
+    data = opts
+    |> Map.new
+    |> camelize_keys
+    |> Map.merge(%{
+      "StreamArn" => stream_arn,
+      "ShardId" => shard_id,
+      "ShardIteratorType" => shard_iterator_type |> upcase
+    })
+
+    request(:get_shard_iterator, data)
+  end
+
+  defp request(action, data, opts \\ %{}) do
+    operation =
+      action
+      |> Atom.to_string
+      |> Macro.camelize
+
+    ExAws.Operation.JSON.new(:dynamodb_streams, %{
+      data: data,
+      headers: [
+        {"x-amz-target", "#{@namespace}.#{operation}"},
+        {"content-type", "application/x-amz-json-1.0"}
+      ]
+    } |> Map.merge(opts))
+  end
+
+end

--- a/test/lib/ex_aws/dynamo_streams/integration_test.exs
+++ b/test/lib/ex_aws/dynamo_streams/integration_test.exs
@@ -1,0 +1,57 @@
+defmodule ExAws.DynamoStreamsIntegrationTest do
+  alias ExAws.{Dynamo, DynamoStreams}
+  use ExUnit.Case, async: true
+  require Logger
+
+  ## These tests run against DynamoDb Local unless otherwise specified
+  #
+  # http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
+  # In this way they can safely delete data and tables without risking actual data on
+  # Dynamo
+  #
+
+  setup_all do
+    Dynamo.delete_table("StreamUser") |> ExAws.request
+    Dynamo.create_table("StreamUser", [email: :hash, age: :range], [email: :string, age: :number], 1, 1) |> ExAws.request!
+    Dynamo.update_table("StreamUser", stream_specification: %{ stream_enabled: true, stream_view_type: "NEW_AND_OLD_IMAGES"}) |> ExAws.request!
+    %{"Table" => %{ "LatestStreamArn" => arn }} = Dynamo.describe_table("StreamUser") |> ExAws.request!
+    {:ok, [arn: arn]}
+  end
+
+  test "#validate arn", context do
+    assert context[:arn] =~ "arn:aws:dynamodb:ddblocal:000000000000:table/StreamUser/stream"
+  end
+
+  test "#list streams" do
+    assert {:ok, _} = DynamoStreams.list_streams |> ExAws.request
+  end
+
+  test "#list streams (aws)" do
+    assert {:ok, %{"Streams" => _}} = DynamoStreams.list_streams |> ExAws.request(
+      host: {"$region", "streams.dynamodb.$region.amazonaws.com"},
+      region: "us-east-1",
+      port: 80
+    )
+  end
+
+  test "#describe stream", context do
+    assert {:ok, %{"StreamDescription" => _}} = DynamoStreams.describe_stream(context[:arn]) |> ExAws.request
+  end
+
+  test "#insert record and retrieve from stream", context do
+    user = %Test.User{email: "foo@bar.com", name: %{first: "bob", last: "bubba"}, age: 23, admin: false}
+    assert Dynamo.put_item("StreamUser", user) |> ExAws.request
+    # There should only be one shard in our test, so grab that one
+    {:ok, %{"StreamDescription" => %{"Shards" => [%{"ShardId" => shard}|_]}}} = DynamoStreams.describe_stream(context[:arn]) |> ExAws.request
+    assert shard =~ "shardId"
+    # Retrieve the shard iterator
+    assert {:ok, %{"ShardIterator" => iterator}} = DynamoStreams.get_shard_iterator(context[:arn], shard, :trim_horizon) |> ExAws.request
+    assert {:ok, %{"Records" => [record]}} = DynamoStreams.get_records(iterator) |> ExAws.request
+
+    item = record["dynamodb"]["NewImage"]
+    |> Dynamo.decode_item(as: Test.User)
+
+    assert item == user
+  end
+
+end


### PR DESCRIPTION
Attempt 2, this time it actually works 🙁.

Dynamo Streams uses the "dynamodb" service name for the signing of all of the operations, but requires a different URL. Rather than trying to hack something into the `:dynamodb` config key I added a `:service_override` config option... it's not super elegant, I'm certainly open to suggestions on improving this.

I've added a `list_streams` call that hits live aws from the integration test and have tested the remaining operations against real streams now.