### PR TITLE
fix iam role detection in EC2

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -19,7 +19,7 @@ defmodule ExAws.InstanceMeta do
   end
 
   def instance_role(config) do
-    ExAws.InstanceMeta.request(config, "/iam/security-credentials/")
+    ExAws.InstanceMeta.request(config, @meta_path_root <> "/iam/security-credentials/")
   end
 
   def task_role_credentials(config) do


### PR DESCRIPTION
this was broken in #294 

```
** (exit) :badarg
     (kernel) gen_tcp.erl:148: :gen_tcp.connect/4
    (hackney) src/hackney_connect.erl:246: :hackney_connect.do_connect/5
    (hackney) src/hackney_connect.erl:37: :hackney_connect.connect/5
    (hackney) src/hackney.erl:328: :hackney.request/5
     (ex_aws) lib/ex_aws/request/hackney.ex:20: ExAws.Request.Hackney.request/5
     (ex_aws) lib/ex_aws/instance_meta.ex:18: ExAws.InstanceMeta.request/2
     (ex_aws) lib/ex_aws/instance_meta.ex:36: ExAws.InstanceMeta.instance_role_credentials/1
```