### PR TITLE
Remove configparser_ex requirement in ec2 environments

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -4,8 +4,8 @@ defmodule ExAws.Config.Defaults do
   """
 
   @common %{
-    access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role],
-    secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, {:awscli, "default", 30}, :instance_role],
+    access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
+    secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
     http_client: ExAws.Request.Hackney,
     json_codec: Poison,
     retries: [

--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -22,7 +22,7 @@ if Code.ensure_loaded?(ConfigParser) do
 
     def strip_key_prefix(credentials) do
       credentials
-      |> Enum.filter(fn({key, val}) -> Enum.member?(~w(aws_access_key_id aws_secret_access_key aws_session_token region), key) end)
+      |> Enum.filter(fn({key, _val}) -> Enum.member?(~w(aws_access_key_id aws_secret_access_key aws_session_token region), key) end)
       |> Enum.reduce(%{}, fn({key, val}, acc) ->
         updated_key = key
         |> String.replace_leading("aws_", "")


### PR DESCRIPTION
Looking at the discussion on #245 I think the intention was for configparser_ex to be optional, but with the `raise` blocks and the addition of the `:awscli` to the default config resolution list you'll always get an error before attempting to retrieve ec2 credentials.

also fixed an unused variable warning.