### PR TITLE
Update SweetXml version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule ExAws.Mixfile do
 
   defp deps(:test_dev) do
     [
-      {:sweet_xml, "~> 0.5", optional: true},
+      {:sweet_xml, "~> 0.6", optional: true},
       {:ex_doc, "~> 0.14", only: :dev},
       {:hackney, "~> 1.6.5", optional: true},
       {:poison, ">= 1.2.0", optional: true},


### PR DESCRIPTION
`SweetXml` version `~> 0.5` doesn't seem to have the method `transform_by` anymore (probably had at some point). That's the method some parsers are referring to: 

https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/sqs/parsers.ex#L59

Version `~> 0.6` has it though