### PR TITLE
Properly format SNS MessageAttributes

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -104,7 +104,7 @@ defmodule ExAws.SNS do
   end
 
   def build_message_attribute({%{name: name, data_type: data_type, value: {value_type, value}}, i}, params) do
-    param_root = "MessageAttribute.#{i}"
+    param_root = "MessageAttribute.entry.#{i + 1}"
     value_type = value_type |> to_string |> String.capitalize
 
     params

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"bypass": {:hex, :bypass, "0.5.1", "cf3e8a4d376ee1dcd89bf362dfaf1f4bf4a6e19895f52fdc2bafbd8207ce435f", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
-  "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "configparser_ex": {:hex, :configparser_ex, "0.2.1", "47a15fa6ebc7d5284bd6dbe1a88be7315fde91a1328915739509c5b75e26eb93", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
@@ -7,7 +7,7 @@
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "gen_stage": {:hex, :gen_stage, "0.8.0", "a76e3f0530f86fae8b8a1021c06527b1ec171cf4c0bdfecd8d5ad0376d1205af", [:mix], []},
-  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
@@ -16,5 +16,5 @@
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "sweet_xml": {:hex, :sweet_xml, "0.6.1", "a56f235171f35a32807ce44798dedc748ce249fca574674fecd29c1321cab0de", [:mix], []}}

--- a/test/lib/ex_aws/sns_test.exs
+++ b/test/lib/ex_aws/sns_test.exs
@@ -86,6 +86,25 @@ defmodule ExAws.SNSTest do
     assert expected == SNS.publish("{\"message\": \"MyMessage\"}", [topic_arn: "arn:aws:sns:us-east-1:982071696186:test-topic"]).params
   end
 
+  test"#publish with message attributes" do
+    expected = %{
+      "Action" => "Publish",
+      "Message" => "Hello World",
+      "TopicArn" => "arn:aws:sns:us-east-1:982071696186:test-topic",
+      "MessageAttribute.entry.1.Name" => "SenderID",
+      "MessageAttribute.entry.1.Value.DataType" => "String",
+      "MessageAttribute.entry.1.Value.StringValue" => "sender"
+    }
+
+    attrs = [%{
+      name: "SenderID",
+      data_type: :string,
+      value: {:string, "sender"}
+    }]
+
+    assert expected == SNS.publish("Hello World", [topic_arn: "arn:aws:sns:us-east-1:982071696186:test-topic", message_attributes: attrs]).params
+  end
+
   test "#subscribe" do
     expected = %{
       "Action"   => "Subscribe",
@@ -170,16 +189,16 @@ defmodule ExAws.SNSTest do
     expected = %{
       "Action" => "Publish",
       "Message" => "message",
-      "MessageAttribute.0.Name" => "AWS.SNS.SMS.SenderID",
-      "MessageAttribute.0.Value.DataType" => "String",
-      "MessageAttribute.1.Name" => "AWS.SNS.SMS.MaxPrice",
-      "MessageAttribute.1.Value.DataType" => "String",
-      "MessageAttribute.2.Name" => "AWS.SNS.SMS.SMSType",
-      "MessageAttribute.2.Value.DataType" => "String",
-      "PhoneNumber" => "+15005550006",
-      "MessageAttribute.0.Value.StringValue" => "sender",
-      "MessageAttribute.1.Value.StringValue" => "0.8",
-      "MessageAttribute.2.Value.StringValue" => "Transactional"
+      "MessageAttribute.entry.1.Name" => "AWS.SNS.SMS.SenderID",
+      "MessageAttribute.entry.1.Value.DataType" => "String",
+      "MessageAttribute.entry.1.Value.StringValue" => "sender",
+      "MessageAttribute.entry.2.Name" => "AWS.SNS.SMS.MaxPrice",
+      "MessageAttribute.entry.2.Value.DataType" => "String",
+      "MessageAttribute.entry.2.Value.StringValue" => "0.8",
+      "MessageAttribute.entry.3.Name" => "AWS.SNS.SMS.SMSType",
+      "MessageAttribute.entry.3.Value.DataType" => "String",
+      "MessageAttribute.entry.3.Value.StringValue" => "Transactional",
+      "PhoneNumber" => "+15005550006"
     }
 
     message_attributes = [


### PR DESCRIPTION
AWS expects MessageAttributes, as a list, to be formatted like so:

```
"MessageAttribute.entry.1.Name" => "value"
```

SNS currently formats attributes without "entry" and with 0 indexing:

```
"MessageAttribute.0.Name" => "value"
```

This results in the following error when you try to publish a message
with MessageAttributes:

```
{:error,
 {:http_error, 400,
  %{code: "MalformedInput", detail: "",
    message: "Top level element may not be treated as a list",
    request_id: "3fc49509-919d-57a3-8147-c5faf4348859", type: "Sender"}}}
```

This has already been fixed elsewhere. See the following examples:

- https://github.com/CargoSense/ex_aws/blob/7082f43acabf283d2e98673ee080e9122c737b97/test/lib/ex_aws/sns_test.exs#L40-L41
- https://github.com/CargoSense/ex_aws/blob/7082f43acabf283d2e98673ee080e9122c737b97/test/lib/ex_aws/sns_test.exs#L208-L213