### PR TITLE
Fix S3 bucket creation for the us-east-1 region

### DIFF
--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -31,6 +31,47 @@ defmodule ExAws.S3Test do
     )
   end
 
+  test "#put_bucket with non-us-east-1 region" do
+    region = "not-us-east-1"
+    bucket = "new.bucket"
+    expected = %Operation.S3{
+      body: """
+      <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <LocationConstraint>#{region}</LocationConstraint>
+      </CreateBucketConfiguration>
+      """,
+      bucket: bucket,
+      path: "/",
+      http_method: :put
+    }
+
+    assert expected == S3.put_bucket(bucket, region)
+  end
+
+  test "#put_bucket with us-east-1 region" do
+    bucket = "new.bucket"
+    expected = %Operation.S3{
+      body: "",
+      bucket: bucket,
+      path: "/",
+      http_method: :put
+    }
+
+    assert expected == S3.put_bucket(bucket, "us-east-1")
+  end
+
+  test "#put_bucket with empty region" do
+    bucket = "new.bucket"
+    expected = %Operation.S3{
+      body: "",
+      bucket: bucket,
+      path: "/",
+      http_method: :put
+    }
+
+    assert expected == S3.put_bucket(bucket, "")
+  end
+
   test "#put_object_copy" do
     expected = %Operation.S3{bucket: "dest-bucket",
       headers: %{"x-amz-acl" => "public-read",


### PR DESCRIPTION
For whatever reason, AWS doesn't want anything sent up when creating a
bucket in the "default" region, us-east-1. This ensures that we send up
an empty body whenever creating a bucket in that region.

Relevant AWS documentation here:
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html#RESTBucketPUT-requests-examples

This took me entirely too long to realize.. here are the relevant requests with some ids/hashes removed:

```
iex(4)> ExAws.S3.put_bucket("paired.photos", "") |> ExAws.request!(debug_requests: true)
[debug] Request URL: "https://s3.amazonaws.com/paired.photos/"
[debug] Request HEADERS: [{"Authorization", "AWS4-HMAC-SHA256 Credential=REMOVED/20170206/us-east-1/s3/aws4_request,SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date,Signature=REMOVED"}, {"host", "s3.amazonaws.com"}, {"x-amz-date", "20170206T055437Z"}, {"content-length", 0}, {"x-amz-content-sha256", "REMOVED"}]
[debug] Request BODY: ""
%{body: "",
  headers: [{"x-amz-id-2",
    "REMOVED"},
   {"x-amz-request-id", "8379D57738F7DE25"},
   {"Date", "Mon, 06 Feb 2017 05:54:39 GMT"}, {"Location", "/paired.photos"},
   {"Content-Length", "0"}, {"Server", "AmazonS3"}], status_code: 200}

iex(1)> ExAws.S3.put_bucket("paired.photos1", "") |> ExAws.request!(debug_requests: true)
[debug] Request URL: "https://s3.amazonaws.com/paired.photos1/"
[debug] Request HEADERS: [{"Authorization", "AWS4-HMAC-SHA256 Credential=REMOVED/20170206/us-east-1/s3/aws4_request,SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date,Signature=REMOVED"}, {"host", "s3.amazonaws.com"}, {"x-amz-date", "20170206T055704Z"}, {"content-length", 149}, {"x-amz-content-sha256", "REMOVED"}]
[debug] Request BODY: "<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n  <LocationConstraint></LocationConstraint>\n</CreateBucketConfiguration>\n"
** (ExAws.Error) ExAws Request Error!

{:error, {:http_error, 400, %{body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>InvalidLocationConstraint</Code><Message>The specified location-constraint is not valid</Message><LocationConstraint></LocationConstraint><RequestId>3D3092C4F9C6EBDE</RequestId><HostId>REMOVED</HostId></Error>", headers: [{"x-amz-request-id", "3D3092C4F9C6EBDE"}, {"x-amz-id-2", "REMOVED"}, {"Content-Type", "application/xml"}, {"Transfer-Encoding", "chunked"}, {"Date", "Mon, 06 Feb 2017 05:57:04 GMT"}, {"Connection", "close"}, {"Server", "AmazonS3"}], status_code: 400}}}

    lib/ex_aws.ex:46: ExAws.request!/2
```