### PR TITLE
Add us-east-2 region & endpoint to S3 options

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -51,6 +51,7 @@ defmodule ExAws.Config.Defaults do
       scheme: "https://",
       host: %{
         "us-east-1" => "s3.amazonaws.com",
+        "us-east-2" => "s3-us-east-2.amazonaws.com",
         "us-west-1" => "s3-us-west-1.amazonaws.com",
         "us-west-2" => "s3-us-west-2.amazonaws.com",
         "eu-west-1" => "s3-eu-west-1.amazonaws.com",


### PR DESCRIPTION
I checked the list and this seems to be the only one that's missing. Coincidentally, it's the region I was trying to use for my project 😝 

http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region