### PR TITLE
Fix presigned_url_opts type

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -81,9 +81,9 @@ defmodule ExAws.S3 do
     | customer_encryption_opts
 
   @type presigned_url_opts :: [
-    expires_in: integer,
-    virtual_host: boolean,
-    query_params: [{:key, binary}]
+      {:expires_in, integer}
+    | {:virtual_host, boolean}
+    | {:query_params, [{binary, binary}]}
   ]
 
   @type amz_meta_opts :: [{atom, binary} | {binary, binary}, ...]


### PR DESCRIPTION
The type specification for presigned_url_opts was making dialyzer complain about valid values. This change corrects it.