### PR TITLE
Add basic support for Elastic Transcoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A flexible easy to use set of AWS APIs.
 - `ExAws.Dynamo`
 - `ExAws.DynamoStreams`
 - `ExAws.EC2`
+- `ExAws.ElasticTranscoder`
 - `ExAws.Firehose`
 - `ExAws.Kinesis`
 - `ExAws.KMS`

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -41,6 +41,20 @@ defmodule ExAws.Config.Defaults do
       port: 443,
       service_override: :dynamodb
     },
+    elastictranscoder: %{
+      scheme: "https://",
+      host: %{
+        "us-east-1" => "elastictranscoder.us-east-1.amazonaws.com",
+        "us-west-1" => "elastictranscoder.us-west-1.amazonaws.com",
+        "us-west-2" => "elastictranscoder.us-west-2.amazonaws.com",
+        "ap-south-1" => "elastictranscoder.ap-south-1.amazonaws.com",
+        "ap-southeast-1" => "elastictranscoder.ap-southeast-1.amazonaws.com",
+        "ap-southeast-2" => "elastictranscoder.ap-southeast-2.amazonaws.com",
+        "ap-northeast-1" => "elastictranscoder.ap-northeast-1.amazonaws.com",
+        "eu-west-1" => "elastictranscoder.eu-west-1.amazonaws.com",
+      },
+      region: "us-east-1"
+    },
     lambda: %{
       host: {"$region", "lambda.$region.amazonaws.com"},
       scheme: "https://",

--- a/lib/ex_aws/elastic_transcoder.ex
+++ b/lib/ex_aws/elastic_transcoder.ex
@@ -1,0 +1,127 @@
+defmodule ExAws.ElasticTranscoder do
+  @moduledoc """
+  Operations on AWS Elastic Transcoder
+
+  ### Examples
+  ```
+  ElasticTranscoder.list_pipelines() |> ExAws.request!()
+  ElasticTranscoder.create_job(%{"Key" => "abcd.mp4", ...}) |> ExAws.request!()
+  ```
+  """
+  @api_version_date "2012-09-25"
+
+  ########################
+  ### Pipeline Actions ###
+  ########################
+
+  @doc "List pipelines, may return paginated result"
+  def list_pipelines(next_token \\ nil) do
+    request(:get, "/pipelines", with_next_token(next_token))
+  end
+
+  @doc "Get description of a single pipeline"
+  def read_pipeline(pipeline_id) do
+    request(:get, "/pipelines/#{pipeline_id}")
+  end
+
+  @doc "Create a new pipeline"
+  def create_pipeline(data) do
+    request(:post, "/pipelines", data)
+  end
+
+  @doc "Update an existing pipeline, omit attributes to leave them unchanged"
+  def update_pipeline(pipeline_id, data) do
+  request(:put, "/pipelines/#{pipeline_id}", data)
+  end
+
+  @doc "Update the status of an existing pipeline"
+  def update_pipeline_status(pipeline_id, status) when status in ["Active", "Paused"] do
+  request(:post, "/pipelines/#{pipeline_id}/status", %{"Status" => status})
+  end
+
+  @doc "Update the notification callback SNS queue ARNs of an existing pipeline"
+  def update_pipeline_notifications(pipeline_id, notifications) do
+    request(:post, "/pipelines/#{pipeline_id}/notifications", %{"Notifications" => notifications})
+  end
+
+  @doc "Delete a pipeline"
+  def delete_pipeline(pipeline_id) do
+    request(:delete, "/pipelines/#{pipeline_id}")
+  end
+
+  ###################
+  ### Job Actions ###
+  ###################
+
+  @doc "List jobs of a given pipeline, may return paginated result"
+  def list_jobs_by_pipeline(pipeline_id, next_token \\ nil) do
+    request(:get, "/jobsByPipeline/#{pipeline_id}", with_next_token(next_token))
+  end
+
+  @doc "List jobs with a given status, may return paginated result"
+  def list_jobs_by_status(status, next_token \\ nil) when status in ["Submitted", "Progressing", "Complete", "Canceled", "Error"] do
+    request(:get, "/jobsByStatus/#{status}", with_next_token(next_token))
+  end
+
+  @doc "Get description of a single job"
+  def read_job(job_id) do
+    request(:get, "/jobs/#{job_id}")
+  end
+
+  @doc "Create a new job"
+  def create_job(data) do
+    request(:post, "/jobs", data)
+  end
+
+  @doc "Cancel a pending job"
+  def cancel_job(job_id) do
+    request(:delete, "/jobs/#{job_id}")
+  end
+
+  ######################
+  ### Preset Actions ###
+  ######################
+
+  @doc "List all preset, may return paginated result"
+  def list_presets(next_token \\ nil) do
+    request(:get, "/presets", with_next_token(next_token))
+  end
+
+  @doc "Get description of a single preset"
+  def read_preset(preset_id) do
+    request(:get, "/presets/#{preset_id}")
+  end
+
+  @doc "Create a new preset"
+  def create_preset(data) do
+    request(:post, "/presets", data)
+  end
+
+  @doc "Delete a preset"
+  def delete_preset(preset_id) do
+    request(:delete, "/presets/#{preset_id}")
+  end
+
+  defp with_next_token(nil), do: %{}
+  defp with_next_token(token), do: %{"PageToken" => token}
+
+  defp request(http_method, path, data \\ %{})
+
+  defp request(:get, path, data) do
+    %ExAws.Operation.JSON{
+      http_method: :get,
+      path: "/" <> @api_version_date <> path,
+      params: data,
+      service: :elastictranscoder,
+    }
+  end
+
+  defp request(http_method, path, data) do
+    %ExAws.Operation.JSON{
+      http_method: http_method,
+      path: "/" <> @api_version_date <> path,
+      data: data,
+      service: :elastictranscoder,
+    }
+  end
+end

--- a/lib/ex_aws/operation/json.ex
+++ b/lib/ex_aws/operation/json.ex
@@ -9,6 +9,7 @@ defmodule ExAws.Operation.JSON do
   - DynamoDB
   - Kinesis
   - Lambda (Rest style)
+  - ElasticTranscoder
 
   JSON services are generally pretty simple. You just need to populate the `data`
   attribute with whatever request body parameters need converted to JSON, and set
@@ -23,6 +24,7 @@ defmodule ExAws.Operation.JSON do
     parser: nil,
     path: "/",
     data: %{},
+    params: %{},
     headers: [],
     service: nil,
     before_request: nil

--- a/test/lib/ex_aws/elastic_transcoder_text.exs
+++ b/test/lib/ex_aws/elastic_transcoder_text.exs
@@ -1,0 +1,244 @@
+defmodule ExAws.ElasticTranscoderTest do
+  use ExUnit.Case, async: true
+  alias ExAws.ElasticTranscoder
+
+  ######################
+  ### Pipeline Tests ###
+  ######################
+
+  test "list_pipelines without token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/pipelines",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_pipelines()
+  end
+
+  test "list_pipelines with token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/pipelines?PageToken=1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_pipelines("1234")
+  end
+
+  test "create_pipeline" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :post,
+        path: "/2012-09-25/pipelines",
+        data: %{"Name" => "some-pipeline"},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.create_pipeline(%{"Name" => "some-pipeline"})
+  end
+
+  test "update_pipeline" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :put,
+        path: "/2012-09-25/pipelines/1234",
+        data: %{"Name" => "some-pipeline"},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.update_pipeline(1234, %{"Name" => "some-pipeline"})
+  end
+
+  test "update_pipeline_status" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :post,
+        path: "/2012-09-25/pipelines/1234/status",
+        data: %{"Status" => "Paused"},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.update_pipeline_status(1234, "Paused")
+  end
+
+  test "update_pipeline_notifications" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :post,
+        path: "/2012-09-25/pipelines/1234/notifications",
+        data: %{"Notifications" => %{"Error" => "arn::fake"}},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.update_pipeline_notifications(1234, %{"Error" => "arn::fake"})
+  end
+
+  test "delete_pipeline" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :delete,
+        path: "/2012-09-25/pipelines/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.delete_pipeline("1234")
+  end
+
+  #################
+  ### Job Tests ###
+  #################
+
+  test "list_jobs_by_pipeline without token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/jobsByPipeline/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_jobs_by_pipeline("1234")
+  end
+
+  test "list_jobs_by_pipeline with token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/jobsByPipeline/1234?PageToken=abcd",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_jobs_by_pipeline("1234", "abcd")
+  end
+
+  test "list_jobs_by_status without token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/jobsByStatus/Submitted",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_jobs_by_status("Submitted")
+  end
+
+  test "list_jobs_by_status with token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/jobsByStatus/Submitted?PageToken=abcd",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_jobs_by_status("Submitted", "abcd")
+  end
+
+  test "read_job" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/jobs/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.read_job("1234")
+  end
+
+  test "create_job" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :post,
+        path: "/2012-09-25/jobs",
+        data: %{"Key" => "abcd.mp4"},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.create_job(%{"Key" => "abcd.mp4"})
+  end
+
+  test "cancel_job" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :delete,
+        path: "/2012-09-25/jobs/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.cancel_job("1234")
+  end
+
+  ####################
+  ### Preset Tests ###
+  ####################
+
+  test "list_presets without token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/presets",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_presets()
+  end
+
+  test "list_presets with token" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/presets?PageToken=abcd",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.list_presets("abcd")
+  end
+
+  test "read_preset" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :get,
+        path: "/2012-09-25/presets/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.read_preset("1234")
+  end
+
+  test "create_preset" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :post,
+        path: "/2012-09-25/presets",
+        data: %{"Name" => "some-preset"},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.create_preset(%{"Name" => "some-preset"})
+  end
+
+  test "delete_preset" do
+    expected =
+      %ExAws.Operation.JSON{
+        http_method: :delete,
+        path: "/2012-09-25/presets/1234",
+        data: %{},
+        service: :elastictranscoder,
+      }
+
+      assert expected == ElasticTranscoder.delete_preset("1234")
+  end
+end


### PR DESCRIPTION
This adds really basic support for Amazon Elastic Transcoder. As far as I can tell it adds support for all operations that Amazon provides, but there's no normalizing of either request or response data.

I also didn't add type annotations yet, since I'm not really too familiar with them and it would have taken me way too long to get this out there.

I omitted the `Ascending` query parameter since I can't for the life of me think of any situation where it'd actually be useful.

Let me know if anything needs to be changed.