### PR TITLE
Capitalize "Host" HTTP header field name

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -30,7 +30,7 @@ defmodule ExAws.Auth do
     with {:ok, config} <- validate_config(config) do
       datetime = :calendar.universal_time
       headers = [
-        {"host", URI.parse(url).authority},
+        {"Host", URI.parse(url).authority},
         {"x-amz-date", amz_date(datetime)} |
         headers
       ]


### PR DESCRIPTION
hackney 1.6.6 concatenates duplicate headers instead of replace.

Before sending the request, hackney [checks](https://github.com/benoitc/hackney/blob/9caf8c612d2408498b95da550755c4ab71e48ac2/src/hackney_request.erl#L617) for the `Host` header field and adds it if it's missing. However, it is not case-sensitive. Since ExAws sets this header as `host`, hackney considers the field missing and inserts `Host` with the same value.

When all headers are normalized before sending, they are compared case-insensitively. `Host` and `host` values are concatenated, which results in a header field that looks like this:

```Host:domain.com, domain.com```

Amazon then expects this field as part of the canonical request for signing, causing 403 errors.