### PR TITLE
Fix EC2 filter implementations

### DIFF
--- a/lib/ex_aws/ec2.ex
+++ b/lib/ex_aws/ec2.ex
@@ -1479,16 +1479,12 @@ defmodule ExAws.EC2 do
   @spec describe_tags() :: ExAws.Operation.RestQuery.t
   @spec describe_tags(opts :: describe_tags_opts) :: ExAws.Operation.RestQuery.t
   def describe_tags(opts \\ []) do
-    filters = Keyword.get(opts, :filters, [])
-
     query_params = opts
-    |> Keyword.delete(:filters)
     |> normalize_opts
     |> Map.merge(%{
       "Action"  => "DescribeTags",
       "Version" => @version
       })
-    |> Map.merge(filter_list_builder(filters, "Filter", 1, %{}))
 
     request(:get, "/", query_params)
   end
@@ -2083,9 +2079,18 @@ defmodule ExAws.EC2 do
   defp normalize_opts(opts) do
     opts
     |> Enum.into(%{})
+    |> format_filters
     |> camelize_keys
   end
 
+  defp format_filters(map = %{filters: filters}) do
+    map
+    |> Map.merge(filter_list_builder(filters, "Filter", 1, %{}))
+    |> Map.delete(:filters)
+  end
+  defp format_filters(map = %{}), do: map
+
+  defp list_builder([], _key, _count, _state), do: %{}
   defp list_builder([h | []], key, count, state) do
     Map.put(state, "#{key}.#{count}", h)
   end

--- a/lib/ex_aws/ec2.ex
+++ b/lib/ex_aws/ec2.ex
@@ -1,6 +1,28 @@
 defmodule ExAws.EC2 do
   @moduledoc """
   Operations on AWS EC2
+
+  ## Basic Operations
+
+  A selection of the most common operations from the EC2 API are implemented here.
+  http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Operations.html
+
+  ### Filters
+
+  Many of the `Describe` endpoints allow you to filter based on a number of attributes.
+  Refer to the AWS documentation for the specified method for the acceptable filter values.
+
+  When supplying atoms, underscores will be converted to a dash for compatibility
+  with the API parameters.
+
+  ### Examples
+  ```elixir
+  ExAws.EC2.create_vpc("10.0.0.0/16")
+  ExAws.EC2.describe_instances(filters: [image_id: "ami-1ecae776"])
+  ExAws.EC2.describe_instances(filters: ["network-interface.availability-zone": "us-east-1a"])
+  ExAws.EC2.describe_instances(filters: ["tag:elasticbeanstalk:environment-name": "demo"])
+  ExAws.EC2.describe_instance_status(instances: ["i-e5974f4c"])
+  ```
   """
 
   import ExAws.Utils
@@ -37,7 +59,7 @@ defmodule ExAws.EC2 do
 
   @type run_instances_monitoring_enabled :: enabled :: boolean
 
-  @type filter :: {name :: binary, value :: [binary]}
+  @type filter :: {name :: binary | atom, value :: [binary | atom] | binary | atom}
 
   @type placement :: {
     affinity          :: binary,
@@ -154,94 +176,11 @@ defmodule ExAws.EC2 do
 
   @type create_volume_permission_modifications :: {add :: [create_volume_permission], remove :: [create_volume_permission]}
 
-  @type describe_instances_filters ::
-    affinity                                            :: (:default | :host)                                                          |
-    architecture                                        :: (:i386 | :x86_64)                                                           |
-    availability_zone                                   :: binary                                                                      |
-    block_device_mapping_attach_time                    :: binary                                                                      |
-    block_device_mapping_delete_on_termination          :: boolean                                                                     |
-    block_device_mapping_device_name                    :: binary                                                                      |
-    block_device_mapping_status                         :: (:attaching | :attached | :detaching | :detached)                           |
-    block_device_mapping_volume_id                      :: binary                                                                      |
-    client_token                                        :: binary                                                                      |
-    dns_name                                            :: binary                                                                      |
-    group_id                                            :: binary                                                                      |
-    group_name                                          :: binary                                                                      |
-    host_id                                             :: binary                                                                      |
-    hypervisor                                          :: (:ovm | :xen)                                                               |
-    iam_instance_profile_arn                            :: binary                                                                      |
-    image_id                                            :: binary                                                                      |
-    instance_id                                         :: binary                                                                      |
-    instance_lifecycle                                  :: binary                                                                      |
-    instance_state_code                                 :: integer                                                                     |
-    instance_state_name                                 :: (:pending | :running | :shutting_down | :terminated | :stopping | :stopped) |
-    instance_type                                       :: binary                                                                      |
-    instance_group_id                                   :: binary                                                                      |
-    instance_group_name                                 :: binary                                                                      |
-    ip_address                                          :: binary                                                                      |
-    kernel_id                                           :: binary                                                                      |
-    key_name                                            :: binary                                                                      |
-    launch_index                                        :: (pos_integer | 0)                                                           |
-    launch_time                                         :: binary                                                                      |
-    monitoring_state                                    :: (:disabled | :enabled)                                                      |
-    owner_id                                            :: binary                                                                      |
-    placement_group_name                                :: binary                                                                      |
-    platform                                            :: (binary | :windows)                                                         |
-    private_dns_name                                    :: binary                                                                      |
-    private_ip_address                                  :: binary                                                                      |
-    product_code                                        :: binary                                                                      |
-    product_code_type                                   :: (:devpay | :marketplace)                                                    |
-    ramdisk_id                                          :: binary                                                                      |
-    reason                                              :: binary                                                                      |
-    requester_id                                        :: binary                                                                      |
-    reservation_id                                      :: binary                                                                      |
-    root_device_name                                    :: binary                                                                      |
-    root_device_type                                    :: binary                                                                      |
-    source_dest_check                                   :: binary                                                                      |
-    spot_instance_request_id                            :: binary                                                                      |
-    state_reason_code                                   :: binary                                                                      |
-    state_reason_message                                :: binary                                                                      |
-    subnet_id                                           :: binary                                                                      |
-    tag                                                 :: tag_key <> tag_value                                                        |
-    tag_key                                             :: binary                                                                      |
-    tag_value                                           :: binary                                                                      |
-    tenancy                                             :: (:default | :default | :host)                                               |
-    virtualization_type                                 :: (:paravirtual | :hvm)                                                       |
-    vpc_id                                              :: binary                                                                      |
-    network_interface_description                       :: binary                                                                      |
-    network_interface_subnet_id                         :: binary                                                                      |
-    network_interface_vpc_id                            :: binary                                                                      |
-    network_interface_network_interface_id              :: binary                                                                      |
-    network_interface_owner_id                          :: binary                                                                      |
-    network_interface_availability_zone                 :: binary                                                                      |
-    network_interface_requester_id                      :: binary                                                                      |
-    network_interface_requester_managed                 :: binary                                                                      |
-    network_interface_status                            :: (:available | :in_use)                                                      |
-    network_interface_mac_address                       :: binary                                                                      |
-    network_interface_private_dns_name                  :: binary                                                                      |
-    network_interface_source_dest_check                 :: binary                                                                      |
-    network_interface_group_id                          :: binary                                                                      |
-    network_interface_group_name                        :: binary                                                                      |
-    network_interface_attachment_attachment_id          :: binary                                                                      |
-    network_interface_attachment_instance_id            :: binary                                                                      |
-    network_interface_attachment_instance_owner_id      :: binary                                                                      |
-    network_interface_addresses_private_ip_address      :: binary                                                                      |
-    network_interface_attachment_device_index           :: binary                                                                      |
-    network_interface_attachment_status                 :: (:attaching | :attached | :detaching | :detached)                           |
-    network_interface_attachment_attach_time            :: binary                                                                      |
-    network_interface_attachment_delete_on_termination  :: boolean                                                                     |
-    network_interface_addresses_primary                 :: binary                                                                      |
-    network_interface_addresses_association_public_ip   :: binary                                                                      |
-    network_interface_addresses_association_ip_owner_id :: binary                                                                      |
-    association_public_ip                               :: binary                                                                      |
-    association_allocation_id                           :: binary                                                                      |
-    association_association_id                          :: binary
-
   @type describe_instances_opts :: [
-    {:dry_run, boolean}            |
-    [{:filter_1, describe_instances_filters}, ...]     |
-    [{:instance_1, [binary]}, ...] |
-    {:max_results, integer}        |
+    {:dry_run, boolean}                        |
+    {:filters, [filter]}                       |
+    {:instances, [binary]}                     |
+    {:max_results, integer}                    |
     {:next_token, binary}
   ]
   @doc """
@@ -250,6 +189,7 @@ defmodule ExAws.EC2 do
   @spec describe_instances() :: ExAws.Operation.RestQuery.t
   @spec describe_instances(opts :: describe_instances_opts) :: ExAws.Operation.RestQuery.t
   def describe_instances(opts \\ []) do
+
     query_params = opts
     |> normalize_opts
     |> Map.merge(%{
@@ -264,23 +204,10 @@ defmodule ExAws.EC2 do
 
   @type instance_state_names :: :pending | :running | :shutting_down | :terminated | :stopping | :stopped
 
-  @type describe_instance_status_filters ::
-    availability_zone            :: binary                                                                   |
-    event_code                   :: event_codes                                                              |
-    event_description            :: binary                                                                   |
-    event_not_after              :: binary                                                                   |
-    event_not_before             :: binary                                                                   |
-    instance_state_code          :: integer                                                                  |
-    instance_state_name          :: instance_state_names                                                     |
-    instance_status_reachability :: (:passed | :failed | :initializing | :insufficient_data)                 |
-    instance_status_status       :: (:ok | :impaired | :initializing | :insufficient_data | :not_applicable) |
-    system_status_reachability   :: (:passed | :failed | :initializing | :insufficient_data)                 |
-    system_status_status         :: (:ok | :impaired | :initializing | :insufficient_data | :not_applicable)
-
   @type describe_instance_status_opts :: [
     {:dry_run, boolean}                                  |
-    [{:filter_1, describe_instance_status_filters}, ...] |
-    [{:instance_1, [binary]}, ...]                       |
+    {:filters, [filter]}                                 |
+    {:instances, [binary]}                               |
     {:include_all_instances, boolean}                    |
     {:max_results, integer}                              |
     {:next_token, binary}
@@ -292,12 +219,15 @@ defmodule ExAws.EC2 do
   @spec describe_instance_status() :: ExAws.Operation.RestQuery.t
   @spec describe_instance_status(opts :: describe_instance_status_opts) :: ExAws.Operation.RestQuery.t
   def describe_instance_status(opts \\ []) do
+    instance_ids = Keyword.get(opts, :instances, [])
     query_params = opts
+    |> Keyword.delete(:instances)
     |> normalize_opts
     |> Map.merge(%{
       "Action"  => "DescribeInstanceStatus",
       "Version" => @version
       })
+    |> Map.merge(list_builder(instance_ids, "InstanceId", 1, %{}))
 
     request(:get, "/", query_params)
   end
@@ -344,8 +274,7 @@ defmodule ExAws.EC2 do
 
   @type start_instances_opts :: [
     {:additional_info, binary} |
-    {:dry_run, boolean}        |
-    [{:instance_id_1, [binary]}, ...]
+    {:dry_run, boolean}
   ]
   @doc """
   Starts an Amazon EBS-backed AMI that was previously stopped.
@@ -366,8 +295,7 @@ defmodule ExAws.EC2 do
 
   @type stop_instances_opts :: [
     {:dry_run, boolean} |
-    {:force, boolean}   |
-    [{:instance_id_1, [binary]}, ...]
+    {:force, boolean}
   ]
   @doc """
   Stops an Amazon EBS-backed AMI that was previously started.
@@ -387,8 +315,7 @@ defmodule ExAws.EC2 do
   end
 
   @type terminate_instances_opts :: [
-    {:dry_run, boolean} |
-    [{:instance_id_1, [binary]}, ...]
+    {:dry_run, boolean}
   ]
   @doc """
   Shuts down one or more instances. Terminated instances remain visible after
@@ -409,8 +336,7 @@ defmodule ExAws.EC2 do
   end
 
   @type reboot_instances_opts :: [
-    {:dry_run, boolean} |
-    [{:instance_id_1, [binary]}, ...]
+    {:dry_run, boolean}
   ]
   @doc """
   Requests a reboot of one or more instances. This operation is asynchronous; it
@@ -436,7 +362,6 @@ defmodule ExAws.EC2 do
     {:description, binary}               |
     {:dry_run, boolean}                  |
     {:end_time, datetime}                |
-    [{:instance_id_1, [binary]}, ...]    |
     [{:reason_code_1, reason_code}, ...] |
     {:start_time, datetime}              |
     {:status, :ok | :impaired}
@@ -461,8 +386,7 @@ defmodule ExAws.EC2 do
   end
 
   @type monitor_instances_opts :: [
-    {:dry_run, boolean} |
-    [{:instance_id_1, [binary]}, ...]
+    {:dry_run, boolean}
   ]
   @doc """
   Enables monitoring for a running instance.
@@ -482,8 +406,7 @@ defmodule ExAws.EC2 do
   end
 
   @type unmonitor_instances_opts :: [
-    {:dry_run, boolean} |
-    [{:instance_id_1, [binary]}, ...]
+    {:dry_run, boolean}
   ]
   @doc """
   Disables monitoring for a running instance.
@@ -629,15 +552,9 @@ defmodule ExAws.EC2 do
 
   @type availability_zone_states :: :available | :information | :impaired | :unavailable
 
-  @type describe_availability_zones_filters ::
-    message     :: binary                   |
-    region_name :: binary                   |
-    state       :: availability_zone_states |
-    zone_name   :: binary
-
   @type describe_availability_zones_opts :: [
-    {:dry_run, boolean}                                     |
-    [{:filter_1, describe_availability_zones_filters}, ...] |
+    {:dry_run, boolean}           |
+    {:filters, [filter]}          |
     [{:zone_name_1, [binary]}, ...]
   ]
   @doc """
@@ -657,11 +574,9 @@ defmodule ExAws.EC2 do
     request(:get, "/", query_params)
   end
 
-  @type describe_regions_filters :: endpoint :: binary | region_name :: binary
-
   @type describe_regions_opts :: [
-    {:dry_run, boolean}                          |
-    [{:filter_1, describe_regions_filters}, ...] |
+    {:dry_run, boolean}           |
+    {:filters, [filter]}          |
     [{:region_name_1, [binary]}, ...]
   ]
   @doc """
@@ -737,40 +652,10 @@ defmodule ExAws.EC2 do
     request(:post, "/", query_params)
   end
 
-  @type describe_images_filters ::
-    architecture :: (:i386 | :x86_64)                                           |
-    block_device_mapping_delete_on_termination :: boolean                       |
-    block_device_mapping_device_name :: binary                                  |
-    block_device_mapping_snapshot_id :: binary                                  |
-    block_device_mapping_volume_size :: integer                                 |
-    block_device_mapping_volume_type :: (:gp2 | :io1 | :st1 | :sc1 | :standard) |
-    description :: binary                                                       |
-    hypervisor :: (:ovm | :xen)                                                 |
-    image_id :: binary                                                          |
-    image_type :: (:machine | :kernel | :ramdisk)                               |
-    is_public :: boolean                                                        |
-    kernel_id :: binary                                                         |
-    manifest_location :: binary                                                 |
-    name :: binary                                                              |
-    owner_alias :: binary                                                       |
-    platform :: (binary | :windows)                                             |
-    product_code :: binary                                                      |
-    product_code_type :: (:devpay | :marketplace)                               |
-    ramdisk_id :: binary                                                        |
-    root_device_name :: binary                                                  |
-    root_device_type :: (:ebs | :instance_store)                                |
-    state :: (:available | :pending | :failed)                                  |
-    state_reason_code :: binary                                                 |
-    state_reason_message :: binary                                              |
-    tag :: tag_key <> tag_value                                                 |
-    tag_key :: binary                                                           |
-    tag_value :: binary                                                         |
-    virtualization_type :: (:paravirtual | :hvm)
-
   @type describe_images_opts :: [
     {:dry_run, boolean}                         |
     [{:executable_by_1, [binary]}, ...]         |
-    [{:filter_1, describe_images_filters}, ...] |
+    {:filters, [filter]}                        |
     [{:image_id_1, [binary]}, ...]              |
     [{:owner_1, [binary]}, ...]
   ]
@@ -916,11 +801,9 @@ defmodule ExAws.EC2 do
   ### Key Pairs Actions ###
   #########################
 
-  @type describe_key_pairs_filters :: fingerprint :: binary | key_name :: binary
-
   @type describe_key_pairs_opts :: [
-    {:dry_run, boolean}                            |
-    [{:filter_1, describe_key_pairs_filters}, ...] |
+    {:dry_run, boolean}           |
+    {:filters, [filter]}          |
     [{:key_name_1, [binary]}, ...]
   ]
   @doc """
@@ -1047,26 +930,10 @@ defmodule ExAws.EC2 do
   ### Security Groups Actions ###
   ###############################
 
-  @type describe_security_groups_filters ::
-    description :: binary                                     |
-    egress_ip_permission_prefix_list_id :: binary             |
-    group_id :: binary                                        |
-    group_name :: binary                                      |
-    ip_permission_cidr :: binary                              |
-    ip_permission_from_port :: pos_integer                    |
-    ip_permission_group_id :: binary                          |
-    ip_permission_protocol :: (:tcp | :udp | :icmp | integer) |
-    ip_permission_to_port :: pos_integer                      |
-    ip_permission_user_id :: binary                           |
-    owner_id :: binary                                        |
-    tag_key :: binary                                         |
-    tag_value :: binary                                       |
-    vpc_id :: binary
-
   @type describe_security_groups_opts :: [
-    {:dry_run, boolean}                                  |
-    [{:filter_1, describe_security_groups_filters}, ...] |
-    [{:group_id_1, [binary]}, ...]                       |
+    {:dry_run, boolean}                |
+    {:filters, [filter]}               |
+    [{:group_id_1, [binary]}, ...]     |
     [{:group_name_1, [binary]}, ...]
   ]
   @doc """
@@ -1225,19 +1092,9 @@ defmodule ExAws.EC2 do
   ### VPCs Actions ###
   ####################
 
-  @type describe_vpcs_filters ::
-    cidr            :: binary                  |
-    dhcp_options_id :: binary                  |
-    is_default      :: binary                  |
-    state           :: (:pending | :available) |
-    tag             :: tag_key <> tag_value    |
-    tag_key         :: binary                  |
-    tag_value       :: binary                  |
-    vpc_id          :: binary
-
   @type describe_vpcs_opts :: [
-    {:dry_run, boolean}                       |
-    [{:filter_1, describe_vpcs_filters}, ...] |
+    {:dry_run, boolean}           |
+    {:filters, [filter]}          |
     [{:vpc_id_1, [binary]}, ...]
   ]
   @doc """
@@ -1343,21 +1200,9 @@ defmodule ExAws.EC2 do
   ### Subnets Actions ###
   #######################
 
-  @type describe_subnets_filters ::
-    availability_zone          :: binary                  |
-    available_ip_address_count :: integer                 |
-    cidr_block                 :: binary                  |
-    default_for_az             :: boolean                 |
-    state                      :: (:pending | :available) |
-    subnet_id                  :: binary                  |
-    tag                        :: tag_key <> tag_value    |
-    tag_key                    :: binary                  |
-    tag_value                  :: binary                  |
-    vpc_id                     :: binary
-
   @type describe_subnets_opts :: [
-    {:dry_run, boolean}                          |
-    [{:filter_1, describe_subnets_filters}, ...] |
+    {:dry_run, boolean}                        |
+    {:filters, [filter]}                       |
     [{:subnet_id_1, [binary]}, ...]
   ]
   @doc """
@@ -1537,27 +1382,9 @@ defmodule ExAws.EC2 do
   ### Elastic Block Stores Actions ###
   ####################################
 
-  @type describe_volumes_filters ::
-    attachment_attach_time           :: binary                                                            |
-    attachment_delete_on_termination :: boolean                                                           |
-    attachment_device                :: binary                                                            |
-    attacment_instance_id            :: binary                                                            |
-    attacment_status                 :: (:attaching | :attached | :detaching | :detached)                 |
-    availability_zone                :: binary                                                            |
-    create_time                      :: binary                                                            |
-    encrypted                        :: boolean                                                           |
-    size                             :: pos_integer                                                       |
-    snapshot_id                      :: binary                                                            |
-    status                           :: (:created | :available | :in_use | :deleting | :deleted | :error) |
-    tag                              :: tag_key <> tag_value                                              |
-    tag_key                          :: binary                                                            |
-    tag_value                        :: binary                                                            |
-    volume_id                        :: binary                                                            |
-    volume_type                      :: (:gp2 | :io1 | :st1 | :sc1 | :standard)
-
   @type describe_volumes_opts :: [
     {:dry_run, boolean}                          |
-    [{:filter_1, describe_volumes_filters}, ...] |
+    {:filters, [filter]}                         |
     {:max_results, integer}                      |
     {:next_token, binary}                        |
     [{:volume_id_1, [binary]}, ...]
@@ -1737,25 +1564,11 @@ defmodule ExAws.EC2 do
     request(:post, "/", query_params)
   end
 
-  @type describe_volume_status_filters ::
-    action_code                  :: binary |
-    action_description           :: binary |
-    action_event_id              :: binary |
-    availability_zone            :: binary |
-    event_description            :: binary |
-    event_event_id               :: binary |
-    event_event_type             :: binary |
-    event_not_after              :: binary |
-    event_not_before             :: binary |
-    volume_status_details_name   :: binary |
-    volume_status_details_status :: binary |
-    volume_status_status         :: binary
-
   @type describe_volume_status_opts :: [
-    {:dry_run, boolean}                                 |
-    [{:filter_1, describe_volume_status_filters}, ...] |
-    {:max_results, integer}                             |
-    {:next_token, binary}                               |
+    {:dry_run, boolean}                        |
+    {:filters, [filter]}                       |
+    {:max_results, integer}                    |
+    {:next_token, binary}                      |
     [{:volume_id_1, [binary]}, ...]
   ]
   @doc """
@@ -1774,23 +1587,9 @@ defmodule ExAws.EC2 do
     request(:get, "/", query_params)
   end
 
-  @type describe_snapshots_filters ::
-    description :: binary                           |
-    owner_alias :: binary                           |
-    owner_id    :: binary                           |
-    progress    :: binary                           |
-    snapshot_id :: binary                           |
-    start_time  :: binary                           |
-    status      :: (:pending | :completed | :error) |
-    tag         :: tag_key <> tag_value             |
-    tag_key     :: binary                           |
-    tag_value   :: binary                           |
-    volume_id   :: binary                           |
-    volume_size :: pos_integer
-
   @type describe_snapshots_opts :: [
     {:dry_run, boolean}                            |
-    [{:filter_1, describe_snapshots_filters}, ...] |
+    {:filters, [filter]}                           |
     {:max_results, integer}                        |
     {:next_token, binary}                          |
     [{:owner_1, [binary]}, ...]                    |
@@ -2030,22 +1829,10 @@ defmodule ExAws.EC2 do
 
   @type bundle_instance_states :: :pending | :waiting_for_shutdown | :bundling | :storing | :cancelling | :complete | :failed
 
-  @type describe_bundle_tasks_filters ::
-    bundle_id     :: binary                 |
-    error_code    :: binary                 |
-    error_message :: binary                 |
-    instance_id   :: binary                 |
-    progress      :: binary                 |
-    s3_bucket     :: binary                 |
-    s3_prefix     :: binary                 |
-    start_time    :: binary                 |
-    state         :: bundle_instance_states |
-    update_time   :: binary
-
   @type describe_bundle_tasks_opts :: [
     [{:bundle_id_1, [binary]}, ...] |
     {:dry_run, boolean}             |
-    [{:filter_1, describe_bundle_tasks_filters}, ...]
+    {:filters, [filter]}
   ]
   @doc """
   Describes one or more of your bundling tasks.

--- a/test/lib/ex_aws/ec2/integration_test.exs
+++ b/test/lib/ex_aws/ec2/integration_test.exs
@@ -5,4 +5,21 @@ defmodule ExAws.EC2.IntegrationTest do
     assert {:ok, %{body: body}} = ExAws.EC2.describe_instances |> ExAws.request
     assert body |> String.contains?("DescribeInstancesResponse")
   end
+
+  test "#describe_tags" do
+    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags |> ExAws.request
+    assert body |> String.contains?("DescribeTagsResponse")
+  end
+  
+  test "#describe_tags with basic filters" do
+    params = [filters: [{:key, ["a-key", "b-key"]}, {:value, "a-value"}]]
+    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags(params) |> ExAws.request
+    assert body |> String.contains?("DescribeTagsResponse")
+  end
+
+  test "#describe_tags with resource_type filter" do
+    params = [filters: [{:resource_type, [:customer_gateway]}]]
+    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags(params) |> ExAws.request
+    assert body |> String.contains?("DescribeTagsResponse")
+  end
 end

--- a/test/lib/ex_aws/ec2/integration_test.exs
+++ b/test/lib/ex_aws/ec2/integration_test.exs
@@ -5,21 +5,4 @@ defmodule ExAws.EC2.IntegrationTest do
     assert {:ok, %{body: body}} = ExAws.EC2.describe_instances |> ExAws.request
     assert body |> String.contains?("DescribeInstancesResponse")
   end
-
-  test "#describe_tags" do
-    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags |> ExAws.request
-    assert body |> String.contains?("DescribeTagsResponse")
-  end
-  
-  test "#describe_tags with basic filters" do
-    params = [filters: [{:key, ["a-key", "b-key"]}, {:value, "a-value"}]]
-    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags(params) |> ExAws.request
-    assert body |> String.contains?("DescribeTagsResponse")
-  end
-
-  test "#describe_tags with resource_type filter" do
-    params = [filters: [{:resource_type, [:customer_gateway]}]]
-    assert {:ok, %{body: body}} = ExAws.EC2.describe_tags(params) |> ExAws.request
-    assert body |> String.contains?("DescribeTagsResponse")
-  end
 end

--- a/test/lib/ex_aws/ec2_test.exs
+++ b/test/lib/ex_aws/ec2_test.exs
@@ -1609,6 +1609,41 @@ test "delete_key_pair with options" do
     assert expected == EC2.describe_tags [max_results: 10, next_token: "abc"]
   end
 
+  test "describe_tags with filters" do
+    expected =
+      %ExAws.Operation.RestQuery{service: :ec2,
+        params: %{
+          "Action"     => "DescribeTags",
+          "Version"    => @version,
+          "Filter.1.Name" => "key",
+          "Filter.1.Value.1" => "a-key",
+          "Filter.1.Value.2" => "b-key",
+          "Filter.2.Name" => "resource-id",
+          "Filter.2.Value" => "id",
+        },
+        path: "/",
+        http_method: :get
+      }
+
+    assert expected == EC2.describe_tags filters: [{:key, ["a-key", "b-key"]}, {:resource_id, "id"}]
+
+    expected =
+      %ExAws.Operation.RestQuery{service: :ec2,
+        params: %{
+          "Action"     => "DescribeTags",
+          "Version"    => @version,
+          "Filter.1.Name" => "resource-type",
+          "Filter.1.Value.1" => "customer-gateway",
+          "Filter.2.Name" => "resource-type",
+          "Filter.2.Value.1" => "customer-gateway",
+          "Filter.2.Value.2" => "instance",
+        },
+        path: "/",
+        http_method: :get
+      }
+      assert expected == EC2.describe_tags filters: [{:resource_type, [:customer_gateway]},{:resource_type, [:customer_gateway, :instance]}]
+  end
+
   test "create_tags no options" do
     expected =
       %ExAws.Operation.RestQuery{service: :ec2,

--- a/test/lib/ex_aws/ec2_test.exs
+++ b/test/lib/ex_aws/ec2_test.exs
@@ -1625,7 +1625,7 @@ test "delete_key_pair with options" do
         http_method: :get
       }
 
-    assert expected == EC2.describe_tags filters: [{:key, ["a-key", "b-key"]}, {:resource_id, "id"}]
+    assert expected == EC2.describe_tags filters: [key: ["a-key", "b-key"], resource_id: "id"]
 
     expected =
       %ExAws.Operation.RestQuery{service: :ec2,
@@ -1641,7 +1641,7 @@ test "delete_key_pair with options" do
         path: "/",
         http_method: :get
       }
-      assert expected == EC2.describe_tags filters: [{:resource_type, [:customer_gateway]},{:resource_type, [:customer_gateway, :instance]}]
+      assert expected == EC2.describe_tags filters: [resource_type: [:customer_gateway], resource_type: [:customer_gateway, :instance]]
   end
 
   test "create_tags no options" do


### PR DESCRIPTION
As discussed in https://github.com/CargoSense/ex_aws/issues/241, the filter implementations on the describe methods do not work correctly.

Since I need `describe_tags` I started with that one, and if this looks good I can implement changes in other methods. I borrowed inspiration from JS SDK 
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#describeTags-property


