### PR TITLE
extend ExAws.Request.Url to handle stringified port

### DIFF
--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -11,10 +11,11 @@ defmodule ExAws.Request.Url do
     |> Map.put(:path, operation.path)
     |> normalize_scheme
     |> normalize_path
+    |> convert_port_to_integer
     |> (&struct(URI, &1)).()
     |> URI.to_string
     |> String.trim_trailing("?")
-  end 
+  end
 
   defp query(operation) do
     operation
@@ -30,6 +31,12 @@ defmodule ExAws.Request.Url do
   defp normalize_path(url) do
     url |> Map.update(:path, "", &String.replace(&1, ~r/\/{2,}/, "/"))
   end
+
+  defp convert_port_to_integer(url = %{port: port}) when is_binary(port) do
+    {port, _} = Integer.parse(port)
+    put_in(url[:port], port)
+  end
+  defp convert_port_to_integer(url), do: url
 
   defp normalize_params(params) when is_map(params)  do
     params |> Map.delete("") |> Map.delete(nil)

--- a/test/lib/ex_aws/request/url_test.exs
+++ b/test/lib/ex_aws/request/url_test.exs
@@ -24,6 +24,11 @@ defmodule ExAws.Request.UrlTest do
     assert Url.build(query, config) == "https://example.com:4430/path?foo=bar"
   end
 
+  test "it converts the port to an integer if it is a string", %{query: query, config: config} do
+    config = config |> Map.put(:port, "4430")
+    assert Url.build(query, config) == "https://example.com:4430/path?foo=bar"
+  end
+
   test "it allows passing scheme with trailing ://", %{query: query, config: config} do
     config = config |> Map.put(:scheme, "https://")
     assert Url.build(query, config) == "https://example.com/path?foo=bar"


### PR DESCRIPTION
When the port is provided via an environment variabe it will come in as
a string, e.g.

```ex
config :ex_aws, :s3,
  scheme: {:system, "S3_SCHEME"},
  host: {:system, "S3_HOST"},
  port: {:system, "S3_PORT"}
```

`URI.to_string/1` expects port to be an integer or else it will raise.
This PR makes sure we perform that conversion if necessary to prevent
this exception