### PR TITLE
Update acl_opts to a union type of two item tuples

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -56,7 +56,7 @@ defmodule ExAws.S3 do
   import ExAws.S3.Utils
   alias ExAws.S3.Parsers
 
-  @type acl_opts :: [{:acl, canned_acl} | grant]
+  @type acl_opts :: {:acl, canned_acl} | grant
   @type grant :: {:grant_read, grantee}
     | {:grant_read_acp, grantee}
     | {:grant_write_acp, grantee}
@@ -286,7 +286,7 @@ defmodule ExAws.S3 do
   end
 
   @doc "Update or create a bucket bucket access control"
-  @spec put_bucket_acl(bucket :: binary, opts :: acl_opts) :: ExAws.Operation.S3.t
+  @spec put_bucket_acl(bucket :: binary, opts :: [acl_opts]) :: ExAws.Operation.S3.t
   def put_bucket_acl(bucket, grants) do
     request(:put, bucket, "/", headers: format_acl_headers(grants))
   end
@@ -646,7 +646,7 @@ defmodule ExAws.S3 do
   end
 
   @doc "Create or update an object's access control FIXME"
-  @spec put_object_acl(bucket :: binary, object :: binary, acl :: acl_opts) :: ExAws.Operation.S3.t
+  @spec put_object_acl(bucket :: binary, object :: binary, acl :: [acl_opts]) :: ExAws.Operation.S3.t
   def put_object_acl(bucket, object, acl) do
     headers = acl |> Map.new |> format_acl_headers
     request(:put, bucket, object, headers: headers, resource: "acl")


### PR DESCRIPTION
Problem: The `acl_opts` type is used in two places ([1](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/s3.ex#L639), [2](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/s3.ex#L674)) extending another union type of possible list item types. Putting this type in a list itself is incorrect, as it would lead to code like: `put_object('bucket', 'path', 'content', [[{:acl, :public_read}]]` which fails immediately in [`put_object_headers/1`](https://github.com/CargoSense/ex_aws/blob/e465e3241d04cbe083ff9f4478c9ac050feccca7/lib/ex_aws/s3/utils.ex#L12).

Solution: Define `acl_opts` as a union type of two item tuples and define list variants in those specific type specs.