### PR TITLE
Add sweet_xml to the deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ def deps do
   [
     {:ex_aws, "~> 1.0"},
     {:poison, "~> 2.0"},
-    {:hackney, "~> 1.6"}
+    {:hackney, "~> 1.6"},
+    {:sweet_xml, "~> 0.6"},
   ]
 end
 ```


### PR DESCRIPTION
After upgrading, it was confusing to try and track down why my s3 uploads weren't working, this should help others in the future.

Given that this library is required as far as I can tell if you're working with the s3 commands, what do you think about changing the `parsers.ex` for s3 to raise if `sweet_xml` is not found instead of skipping those operations? I