### PR TITLE
Add ListIdentities call to SES

### DIFF
--- a/lib/ex_aws/ses.ex
+++ b/lib/ex_aws/ses.ex
@@ -15,6 +15,17 @@ defmodule ExAws.SES do
     request(:verify_email_identity, %{"EmailAddress" => email})
   end
 
+  @type list_identities_opt :: {:max_items, pos_integer}
+    | {:next_token, String.t}
+    | {:identity_type, String.t}
+
+  @doc "List identities associated with the AWS account"
+  @spec list_identities(opts :: [] | [list_identities_opt]) :: ExAws.Operation.Query.t
+  def list_identities(opts \\ []) do
+    params = build_opts(opts, [:max_items, :next_token, :identity_type])
+    request(:list_identities, params)
+  end
+
   @doc "Fetch identities verification status and token (for domains)"
   @spec get_identity_verification_attributes([binary]) :: ExAws.Operation.Query.t
   def get_identity_verification_attributes(identities) when is_list(identities) do

--- a/test/lib/ex_aws/ses_test.exs
+++ b/test/lib/ex_aws/ses_test.exs
@@ -30,6 +30,14 @@ defmodule ExAws.SESTest do
     assert expected == SES.list_configuration_sets(max_items: 1, next_token: "QUFBQUF").params
   end
 
+  test "#list_identities" do
+    expected = %{"Action" => "ListIdentities", "MaxItems" => 1, "NextToken" => "QUFBQUF", "IdentityType" => "Domain"}
+    assert expected == SES.list_identities(max_items: 1, next_token: "QUFBQUF", identity_type: "Domain").params
+
+    expected = %{"Action" => "ListIdentities", "MaxItems" => 1, "NextToken" => "QUFBQUF"}
+    assert expected == SES.list_identities(max_items: 1, next_token: "QUFBQUF").params
+  end
+
   describe "#send_email" do
     test "with required params only" do
       dst =  %{to:  ["success@simulator.amazonses.com"]}


### PR DESCRIPTION
This PR adds the ListIdentities call to the SES module. It is almost
identical to `list_configuration_sets` only that it has an additonal
optional parameter for specifying `IdentityType`

API Docs: http://docs.aws.amazon.com/ses/latest/APIReference/API_ListIdentities.html