### PR TITLE
add ListPhoneNumbersOptedOut and OptInPhoneNumber to SNS

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -4,7 +4,7 @@ defmodule ExAws.SNS do
   @moduledoc """
   Operations on AWS SNS
 
-  http://docs.aws.amazon.com/sns/latest/APIReference/API_Operations.html
+  http://docs.aws.amazon.com/sns/latest/api/API_Operations.html
   """
 
   ## Topics
@@ -247,6 +247,23 @@ defmodule ExAws.SNS do
       "AttributeValue" => attribute_value,
       "SubscriptionArn" => subscription_arn
     })
+  end
+
+  @doc "List phone numbers opted out"
+  @spec list_phone_numbers_opted_out() :: ExAws.Operation.Query.t
+  def list_phone_numbers_opted_out() do
+    request(:list_phone_numbers_opted_out, %{})
+  end
+
+  @spec list_phone_numbers_opted_out(next_token :: binary) :: ExAws.Operation.Query.t
+  def list_phone_numbers_opted_out(next_token) do
+    request(:list_phone_numbers_opted_out, %{"NextToken" => next_token})
+  end
+
+  @doc "Opt in phone number"
+  @spec opt_in_phone_number(phone_number :: binary) :: ExAws.Operation.Query.t
+  def opt_in_phone_number(phone_number) do
+    request(:opt_in_phone_number, %{"PhoneNumber" => phone_number})
   end
 
   ## Endpoints

--- a/lib/ex_aws/sns/parsers.ex
+++ b/lib/ex_aws/sns/parsers.ex
@@ -232,6 +232,23 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
+    def parse({:ok, %{body: xml}=resp}, :list_phone_numbers_opted_out) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//ListPhoneNumbersOptedOutResponse",
+                        phone_numbers: ~x"./ListPhoneNumbersOptedOutResult/phoneNumbers/member/text()"sl,
+                        next_token: ~x"./ListPhoneNumbersOptedOutResult/nextToken/text()"s,
+                        request_id: request_id_xpath())
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
+    def parse({:ok, %{body: xml}=resp}, :opt_in_phone_number) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//OptInPhoneNumberResponse",
+                        request_id: request_id_xpath())
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
     def parse(val, _), do: val
 
     defp request_id_xpath do

--- a/test/lib/ex_aws/sns/parser_test.exs
+++ b/test/lib/ex_aws/sns/parser_test.exs
@@ -633,4 +633,41 @@ defmodule ExAws.SNS.ParserTest do
     {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :delete_endpoint)
     assert parsed_doc[:request_id] == "c1d2b191-353c-5a5f-8969-fbdd3900afa8"
   end
+
+  test "#parsing a list_phone_numbers_opted_out response" do
+    rsp = """
+      <ListPhoneNumbersOptedOutResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+        <ListPhoneNumbersOptedOutResult>
+          <nextToken>AAHewfYBWTBhfb4//E2ANouP</nextToken>
+            <phoneNumbers>
+              <member>+15005550006</member>
+            </phoneNumbers>
+          </ListPhoneNumbersOptedOutResult>
+        <ResponseMetadata>
+          <RequestId>db6d6256-6b98-5656-8798-33d0de3d3b47</RequestId>
+        </ResponseMetadata>
+      </ListPhoneNumbersOptedOutResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :list_phone_numbers_opted_out)
+    assert parsed_doc[:request_id] == "db6d6256-6b98-5656-8798-33d0de3d3b47"
+    assert parsed_doc[:phone_numbers] == ["+15005550006"]
+    assert parsed_doc[:next_token] == "AAHewfYBWTBhfb4//E2ANouP"
+  end
+
+  test "#parsing a opt_in_phone_number response" do
+    rsp = """
+      <OptInPhoneNumberResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+        <OptInPhoneNumberResult/>
+        <ResponseMetadata>
+          <RequestId>5839a693-c333-5df8-b06f-f71576ff9bc1</RequestId>
+        </ResponseMetadata>
+      </OptInPhoneNumberResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :opt_in_phone_number)
+    assert parsed_doc[:request_id] == "5839a693-c333-5df8-b06f-f71576ff9bc1"
+  end
 end

--- a/test/lib/ex_aws/sns_test.exs
+++ b/test/lib/ex_aws/sns_test.exs
@@ -184,6 +184,19 @@ defmodule ExAws.SNSTest do
       subscription_arn).params
   end
 
+  test "#list_phone_numbers_opted_out" do
+    expected = %{"Action" => "ListPhoneNumbersOptedOut"}
+    assert expected == SNS.list_phone_numbers_opted_out().params
+
+    expected = %{"Action" => "ListPhoneNumbersOptedOut", "NextToken" => "123456789"}
+    assert expected == SNS.list_phone_numbers_opted_out("123456789").params
+  end
+
+  test "#opt_in_phone_number" do
+    expected = %{"Action" => "OptInPhoneNumber", "PhoneNumber" => "+15005550006"}
+    assert expected == SNS.list_phone_numbers_opted_out("+15005550006").params
+  end
+
   # Test SMS request structure. Credentials via (https://www.twilio.com/docs/api/rest/test-credentials).
   test "#publish_sms" do
     expected = %{


### PR DESCRIPTION
This pr adds both `list_phone_numbers_opted_out` and `opt_in_phone_number` to the `SNS` module.
Also corrected api url for sns documentation which was directing to a 'Looking for Something?' page.


API Docs:
http://docs.aws.amazon.com/sns/latest/api/API_ListPhoneNumbersOptedOut.html
http://docs.aws.amazon.com/sns/latest/api/API_OptInPhoneNumber.html