### PR TITLE
[sqs] Add parsing for error entries in SendMessageBatch response

### DIFF
--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -145,6 +145,7 @@ if Code.ensure_loaded?(SweetXml) do
     end
 
     def parse({:ok, %{body: xml}=resp}, :send_message_batch) do
+      # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html#API_SendMessageBatch_ResponseElements
       parsed_body = xml
       |> SweetXml.xpath(~x"//SendMessageBatchResponse",
                         request_id: request_id_xpath(),
@@ -154,6 +155,14 @@ if Code.ensure_loaded?(SweetXml) do
                           message_id: ~x"./MessageId/text()"s,
                           md5_of_message_body: ~x"./MD5OfMessageBody/text()"s,
                           md5_of_message_attributes: ~x"./MD5OfMessageAttributes/text()"s
+                        ],
+                        # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_BatchResultErrorEntry.html
+                        failures: [
+                          ~x"./SendMessageBatchResult/BatchResultErrorEntry"l,
+                          code: ~x"./Code/text()"s,
+                          id: ~x"./Id/text()"s,
+                          message: ~x"./Message/text()"s,
+                          sender_fault: ~x"./SenderFault/text()"s, # FIXME Cast to boolean
                         ])
       {:ok, Map.put(resp, :body, parsed_body)}
 

--- a/test/lib/ex_aws/sqs/parser_test.exs
+++ b/test/lib/ex_aws/sqs/parser_test.exs
@@ -506,6 +506,12 @@ defmodule ExAws.SQS.ParserTest do
           <MD5OfMessageBody>7fb8146a82f95e0af155278f406862c2</MD5OfMessageBody>
           <MD5OfMessageAttributes>295c5fa15a51aae6884d1d7c1d99ca50</MD5OfMessageAttributes>
         </SendMessageBatchResultEntry>
+        <BatchResultErrorEntry>
+          <Code>test_error_1</Code>
+          <Id>test_error_001</Id>
+          <Message>Big data</Message>
+          <SenderFault>true</SenderFault>
+        </BatchResultErrorEntry>
       </SendMessageBatchResult>
       <ResponseMetadata>
         <RequestId>ca1ad5d0-8271-408b-8d0f-1351bf547e74</RequestId>
@@ -528,6 +534,12 @@ defmodule ExAws.SQS.ParserTest do
     assert "15ee1ed3-87e7-40c1-bdaa-2e49968ea7e9" == second[:message_id]
     assert "7fb8146a82f95e0af155278f406862c2" == second[:md5_of_message_body]
     assert "295c5fa15a51aae6884d1d7c1d99ca50" == second[:md5_of_message_attributes]
+
+    assert [first_error] = response[:failures]
+    assert "test_error_1" == first_error[:code]
+    assert "test_error_001" == first_error[:id]
+    assert "Big data" == first_error[:message]
+    assert "true" == first_error[:sender_fault]
   end
 
   test "it should handle a set queue attributes response" do


### PR DESCRIPTION
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html#API_SendMessageBatch_ResponseElements
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_BatchResultErrorEntry.html

References:

- https://boto3.readthedocs.io/en/latest/reference/services/sqs.html#SQS.Client.send_message_batch
- https://github.com/boto/boto/blob/master/boto/sqs/batchresults.py
- https://github.com/aws/aws-sdk-cpp/blob/master/aws-cpp-sdk-sqs/source/model/BatchResultErrorEntry.cpp
- https://github.com/aws/aws-sdk-go/blob/0bc99f4aa1cf50245de234b1ce0b33463a3ad5fe/service/sqs/api.go#L3689