### PR TITLE
Updated Dynamo create_table example.

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -171,7 +171,7 @@ defmodule ExAws.Dynamo do
     index_name: "my-global-index",
     key_schema: [%{
       attribute_name: "email",
-      attribute_type: "HASH",
+      key_type: "HASH",
     }],
     provisioned_throughput: %{
       read_capacity_units: 1,
@@ -181,7 +181,7 @@ defmodule ExAws.Dynamo do
       projection_type: "KEYS_ONLY",
     }
   }]
-  create_table("TestUsers", [id: :hash], %{id: :string}, 1, 1, secondary_index, [])
+  create_table("TestUsers", [id: :hash], %{id: :string, email: :string}, 1, 1, secondary_index, [])
   ```
 
   """


### PR DESCRIPTION
attribute_type seems to have been replaced by key_type, and the 'email' attribute is required in your attribute definitions for the base table.

HTH
Thanks
A