### PR TITLE
use Base.encode16 :case option instead of piping to String.downcase

### DIFF
--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -27,8 +27,7 @@ defmodule ExAws.Auth.Utils do
 
   def bytes_to_hex(bytes) do
     bytes
-    |> Base.encode16
-    |> String.downcase
+    |> Base.encode16(case: :lower)
   end
 
   def service_name(service), do: service |> Atom.to_string


### PR DESCRIPTION
Not sure if there is a preference for piping to String.downcase, but Base.encode16 has a :case option for this:

```elixir
Base.encode16(case: :lower)
```