### PR TITLE
Add stream support for Dynamo.query/2

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -325,7 +325,7 @@ defmodule ExAws.Dynamo do
     |> build_opts
     |> Map.merge(%{"TableName" => name})
 
-    request(:query, data, %{stream_builder: &ExAws.Dynamo.Lazy.query_scan(name, opts, &1)})
+    request(:query, data, %{stream_builder: &ExAws.Dynamo.Lazy.stream_query(name, opts, &1)})
   end
 
   @doc """

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -325,7 +325,7 @@ defmodule ExAws.Dynamo do
     |> build_opts
     |> Map.merge(%{"TableName" => name})
 
-    request(:query, data)
+    request(:query, data, %{stream_builder: &ExAws.Dynamo.Lazy.query_scan(name, opts, &1)})
   end
 
   @doc """


### PR DESCRIPTION
It appears streams for dynamo queries were never implemented even though there is a [method](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/dynamo/lazy.ex#L31) for it. [`Dynamo.scan/2` implemented the stream builder](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/dynamo.ex#L290), but [`Dynamo.query/2` did not](https://github.com/CargoSense/ex_aws/blob/master/lib/ex_aws/dynamo.ex#L328).