### PR TITLE
Fix incorrectly public functions in Cloudformation module

### DIFF
--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -109,23 +109,23 @@ defmodule ExAws.Utils do
     end)
   end
 
-  def build_indexed_params(param_key, values) when is_list(values) do
-    case String.split(param_key, "{i}") do
+  def build_indexed_params(key_template, values) when is_list(values) do
+    case String.split(key_template, "{i}") do
       [prefix, suffix] -> 
         values
         |> Enum.with_index(1)
         |> Enum.map(fn {value, i} -> {prefix <> "#{i}" <> suffix, value} end)
 
-      _ -> raise ArgumentError, "The Argument param_key is invalid. 
-      Expected a string with exactly one location for an index, got: \"#{param_key}\"
-      Example valid param_key: \"Tags.member.{i}.Key\""
+      _ -> raise ArgumentError, "The Argument key_template is invalid. 
+      Expected a string with exactly one location for an index, got: \"#{key_template}\"
+      Example valid key_template: \"Tags.member.{i}.Key\""
     end
   end
 
-  def build_indexed_params(param_key, value), do: build_indexed_params(param_key, [value])
+  def build_indexed_params(key_template, value), do: build_indexed_params(key_template, [value])
 
-  def build_indexed_params(key_value_pairs) when is_list(key_value_pairs) do
-    Enum.flat_map(key_value_pairs, fn {key, values} -> build_indexed_params(key, values) end)
+  def build_indexed_params(key_templates) when is_list(key_templates) do
+    Enum.flat_map(key_templates, fn {key_template, values} -> build_indexed_params(key_template, values) end)
   end
 
 end

--- a/test/lib/ex_aws/utils_test.exs
+++ b/test/lib/ex_aws/utils_test.exs
@@ -25,11 +25,32 @@ defmodule ExAws.UtilsTest do
     |> camelize_keys(deep: true)
   end
 
-  test "iso_z_to_secs/1" do
-    assert iso_z_to_secs("2015-07-05T22:16:18Z") == 1436134578
+  test "iso_z_to_secs converts iso string to epoch seconds" do
+    assert 1436134578 == iso_z_to_secs("2015-07-05T22:16:18Z")
   end
 
   test "rename_keys renames keys in a list of keywords" do
     assert [d: 1, b: 2, e: 3] == [a: 1, b: 2, c: 3] |> rename_keys(a: :d, c: :e)
+  end
+
+  test "build_indexed_params creates key value pairs from key_template and list" do
+    assert [{"key.1", 1}, {"key.2", 2}] == build_indexed_params("key.{i}", [1,2])
+  end
+
+  test "build_indexed_params creates key value pair from key_template and single element" do
+    assert [{"key.1", 1}] == build_indexed_params("key.{i}", 1)
+  end
+
+  test "build_indexed_params creates key value pairs from list of key_templates" do
+    expected_return = [
+        {"foo.1", 1}, {"foo.2", 2}, 
+        {"bar.1", 3}, {"bar.2", 4},
+      ]
+    index_params = build_indexed_params([ 
+        {"foo.{i}", [1,2]}, 
+        {"bar.{i}", [3,4]},
+      ])
+
+    assert expected_return == index_params
   end
 end


### PR DESCRIPTION
Using `Kernel.apply` in the Cloudformation module look to have cleaned up a lot of boilerplate code for the transforms, but unfortunately also exposed many helper functions to the public interface that **should not be used directly**. This pull request fixes that issue by replacing apply with function patern_matching.  

Also added tests for build_indexed_params. 
