### PR TITLE
Cleanup of cloudformation, and related Utils functions. 

### DIFF
--- a/lib/ex_aws/cloudformation.ex
+++ b/lib/ex_aws/cloudformation.ex
@@ -419,44 +419,44 @@ defmodule ExAws.Cloudformation do
   ### Format Functions ###
   ########################
 
-  defp format_request(:skip_resources, resources) do
-    build_indexed_params("ResourcesToSkip.member", resources)
+  defp format_param(:skip_resources, resources) do
+    flatten_params("ResourcesToSkip.member", resources)
   end
 
-  defp format_request(:stack_status_filters, filters) do
-    build_indexed_params("StackStatusFilter.member", filters |> Enum.map(&upcase/1))
+  defp format_param(:stack_status_filters, filters) do
+    flatten_params("StackStatusFilter.member", filters |> Enum.map(&upcase/1))
   end
 
-  defp format_request(:capabilities, capabilities) do
-    build_indexed_params("Capabilities.member", capabilities |> Enum.map(&upcase/1))
+  defp format_param(:capabilities, capabilities) do
+    flatten_params("Capabilities.member", capabilities |> Enum.map(&upcase/1))
   end
 
-  defp format_request(:parameters, parameters) do
-    build_indexed_params("Parameters.member", parameters)
+  defp format_param(:parameters, parameters) do
+    flatten_params("Parameters.member", parameters)
     |> filter_nil_params
   end
 
-  defp format_request(:notification_arns, notification_arns) do
-    build_indexed_params("NotificationARN.member", notification_arns)
+  defp format_param(:notification_arns, notification_arns) do
+    flatten_params("NotificationARN.member", notification_arns)
   end
 
 
-  defp format_request(:tags, tags) do
+  defp format_param(:tags, tags) do
     tags = for {key, value} <- tags, do: [key: Atom.to_string(key), value: value]
 
-    build_indexed_params("Tags.member", tags)
+    flatten_params("Tags.member", tags)
     |> filter_nil_params
   end
 
-  defp format_request(:resource_types, resource_types) do
-    build_indexed_params("ResourceTypes.member", resource_types)
+  defp format_param(:resource_types, resource_types) do
+    flatten_params("ResourceTypes.member", resource_types)
   end
 
-  defp format_request(:retain_resources, retain_resources) do
-    build_indexed_params("RetainResources.member", retain_resources)
+  defp format_param(:retain_resources, retain_resources) do
+    flatten_params("RetainResources.member", retain_resources)
   end
 
-  defp format_request(:template_stage, template_stage) do
+  defp format_param(:template_stage, template_stage) do
     [{"TemplateStage", camelize_key(template_stage)}]
   end
 

--- a/lib/ex_aws/cloudformation.ex
+++ b/lib/ex_aws/cloudformation.ex
@@ -460,7 +460,7 @@ defmodule ExAws.Cloudformation do
     [{"TemplateStage", camelize_key(template_stage)}]
   end
 
-  # normalize_opts should be refactored to be in Utils
+  # normalize_opts should be refactored into Utils
   defp normalize_opts(opts) do
     opts
     |> Enum.into(%{})

--- a/lib/ex_aws/cloudformation.ex
+++ b/lib/ex_aws/cloudformation.ex
@@ -460,4 +460,11 @@ defmodule ExAws.Cloudformation do
     [{"TemplateStage", camelize_key(template_stage)}]
   end
 
+  # normalize_opts should be refactored to be in Utils
+  defp normalize_opts(opts) do
+    opts
+    |> Enum.into(%{})
+    |> camelize_keys
+  end
+
 end

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -171,8 +171,8 @@ defmodule ExAws.Utils do
         maybe_camelize: 2, maybe_camelize: 1 
       ]
 
-      def flatten_params(params, kwargs \\ [prefix: ""]), 
-        do: ExAws.Utils.flatten_params(params, unquote(inject))
+      def format(params, kwargs \\ [prefix: ""]), 
+        do: ExAws.Utils.format(params, unquote(inject))
       def camelize_keys(opts, kwargs \\ [deep: false]), 
         do: ExAws.Utils.camelize_keys(opts, unquote(inject))
       def camelize_key(opts, kwargs \\ []), 

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -128,12 +128,12 @@ defmodule ExAws.Utils do
     Enum.flat_map(key_templates, fn {key_template, values} -> build_indexed_params(key_template, values) end)
   end
 
-  # a simple macro for calling private format functions if param isn't nul
-  defmacro maybe_format(map, format_name) do
+  # A simple macro for calling private format functions if param isn't nul
+  defmacro maybe_format(params, key) do
     quote do
-      case unquote(argument)[unquote(format_name)] do
+      case unquote(params)[unquote(key)] do
         nil -> []
-        value -> format_request(unquote(format_name), value)
+        value -> format_param(unquote(key), value)
       end
     end
   end

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -155,7 +155,14 @@ defmodule ExAws.Utils do
   def maybe_stringify(elem) when is_atom(elem),      do: Atom.to_string(elem)
   def maybe_stringify(elem) when is_bitstring(elem), do: elem
 
-  defmacro __using__(non_standard_keys: non_standard_keys) do
+  defmacro __using__(kwargs) do
+    inject = 
+      quote do 
+        [ type: unquote(kwargs[:format_type] || :xml), 
+          spec: unquote(kwargs[:non_standard_keys] || %{}) ] 
+        ++ [kwargs] 
+      end
+
     quote do
       import ExAws.Utils, except: [
         flatten_params: 2, flatten_params: 1,  
@@ -165,13 +172,13 @@ defmodule ExAws.Utils do
       ]
 
       def flatten_params(params, kwargs \\ [prefix: ""]), 
-        do: ExAws.Utils.flatten_params(params, [{:spec, unquote(non_standard_keys)} | kwargs])
+        do: ExAws.Utils.flatten_params(params, unquote(inject))
       def camelize_keys(opts, kwargs \\ [deep: false]), 
-        do: ExAws.Utils.camelize_keys(opts, [{:spec, unquote(non_standard_keys)} | kwargs])
+        do: ExAws.Utils.camelize_keys(opts, unquote(inject))
       def camelize_key(opts, kwargs \\ []), 
-        do: ExAws.Utils.camelize_key(opts, [{:spec, unquote(non_standard_keys)} | kwargs])
+        do: ExAws.Utils.camelize_key(opts, unquote(inject))
       def maybe_camelize(opts, kwargs \\ []), 
-        do: ExAws.Utils.maybe_camelize(opts, [{:spec, unquote(non_standard_keys)} | kwargs])
+        do: ExAws.Utils.maybe_camelize(opts, unquote(inject))
     end
   end
 end

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -165,7 +165,7 @@ defmodule ExAws.Utils do
 
     quote do
       import ExAws.Utils, except: [
-        flatten_params: 2, flatten_params: 1,  
+        format: 2, format: 1,  
         camelize_keys: 2, camelize_keys: 1, 
         camelize_key: 2, camelize_key: 1,
         maybe_camelize: 2, maybe_camelize: 1 

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -116,50 +116,33 @@ defmodule ExAws.Utils do
     end)
   end
 
-  # a build_indexed_params util, Adds prefix to nested indexed params 
-  defp add_prefix(prefix, kv_pairs) do
-    kv_pairs
-    |> Enum.map(fn {key, value} -> 
-      {prefix <> "." <> maybe_camelize(key), value} 
-    end)
-  end
 
-
-  # NOTE: build_indexed_params is not tail call optimized 
+  # NOTE: flatten_params is not tail call optimized 
   # but it is unlikely that any AWS params will ever
   # be nested enough for this to  cause a stack overflow
-
-  def build_indexed_params(key, values) when is_list(values) do
-    key = maybe_camelize(key)
-
+  def flatten_params(key, values) when is_list(values) do
     values
     |> Stream.with_index(1)
-    |> Stream.map(fn {value, i} -> 
-      {"#{key}.#{i}", value} end)
+    |> Stream.map(fn {value, i} -> {"#{maybe_camelize(key)}.#{i}", value} end)
     |> Stream.flat_map(fn
-      # if there are nested key value pairs, recuse over nested kv_pairs by calling build_indexed_params again
       {key, kv_pairs} when is_list(kv_pairs) -> 
-        add_prefix(key, kv_pairs) |> build_indexed_params
+        add_prefix(key, kv_pairs) |> flatten_params
         
-      {key, value} ->
+      {key, value} -> 
         [{key, value}]
     end)
     |> Enum.to_list
   end
-
   # When only one key_template and value is passed  
-  def build_indexed_params(key, value) when is_atom(key), 
-  do: [{camelize_key(key), value}]
-  def build_indexed_params(key, value) when is_bitstring(key), 
-  do: [{key, value}]
-
+  def flatten_params(key, value), 
+  do: [{maybe_camelize(key), value}]
   # When multiple key_templates and values pairs are passed
-  def build_indexed_params(kv_pairs) do
-    kv_pairs
-    |> Enum.flat_map(fn {key, values} -> 
-      build_indexed_params(key, values)
-    end)
-  end
+  def flatten_params(kv_pairs),
+  do: Enum.flat_map(kv_pairs, fn {key, value} -> flatten_params(key, value) end)
+ # A flatten_params util, Adds prefix to when flattening nested params 
+  defp add_prefix(prefix, kv_pairs), 
+  do: Enum.map(kv_pairs, fn {key, value} -> {"#{prefix}.#{maybe_camelize(key)}", value} end)
+
 
   # TODO: make a generic normalize_opts
   # def normalize_opts(opts) do
@@ -183,7 +166,7 @@ defmodule ExAws.Utils do
     quote do
       case unquote(argument)[unquote(format_name)] do
         nil -> []
-        value -> format_request(unquote(format_name), value)
+        value -> format_param(unquote(format_name), value)
       end
     end
   end

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -161,12 +161,12 @@ defmodule ExAws.Utils do
     end)
   end
 
-
-  def normalize_opts(opts) do
-    opts
-    |> Enum.into(%{})
-    |> camelize_keys
-  end
+  # TODO: make a generic normalize_opts
+  # def normalize_opts(opts) do
+  #   opts
+  #   |> Enum.into(%{})
+  #   |> camelize_keys
+  # end
 
   def filter_nil_params(opts) do
     opts

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -128,4 +128,14 @@ defmodule ExAws.Utils do
     Enum.flat_map(key_templates, fn {key_template, values} -> build_indexed_params(key_template, values) end)
   end
 
+  # a simple macro for calling private format functions if param isn't nul
+  defmacro maybe_format(map, format_name) do
+    quote do
+      case unquote(argument)[unquote(format_name)] do
+        nil -> []
+        value -> format_request(unquote(format_name), value)
+      end
+    end
+  end
+
 end

--- a/test/lib/ex_aws/cloudformation_test.exs
+++ b/test/lib/ex_aws/cloudformation_test.exs
@@ -21,8 +21,9 @@ defmodule ExAws.CloudformationTest do
       "ResourcesToSkip.member.2" => "test_resource_2",
       "StackName" => "test_stack"
     })
-    assert expected == Cloudformation.continue_update_rollback("test_stack",
-                         [skip_resources: ["test_resource_1", "test_resource_2"]])
+    assert expected == Cloudformation.continue_update_rollback(
+      "test_stack", [skip_resources: ["test_resource_1", "test_resource_2"]]
+    )
   end
 
   test "continue_update_rollback with role arn" do
@@ -69,15 +70,15 @@ defmodule ExAws.CloudformationTest do
       "Parameters.member.2.ParameterKey" => "InstanceType",
       "Parameters.member.2.ParameterValue" => "m1.micro"
       })
-
-    assert expected == Cloudformation.create_stack("test_stack",
+    
+    result = Cloudformation.create_stack(
+      "test_stack", 
       [parameters:
-        [
-          [parameter_key: "AvailabilityZone", parameter_value: "us-east-1a"],
-          [parameter_key: "InstanceType", parameter_value: "m1.micro"]
-        ]
-      ]
-    )
+        [ %{parameter_key: "AvailabilityZone", parameter_value: "us-east-1a"},
+          %{parameter_key: "InstanceType", parameter_value: "m1.micro"} ]
+      ])
+      
+    assert expected == result
   end
 
   test "create_stack with tags" do

--- a/test/lib/ex_aws/cloudformation_test.exs
+++ b/test/lib/ex_aws/cloudformation_test.exs
@@ -216,17 +216,12 @@ defmodule ExAws.CloudformationTest do
 
   test "describe_stacks with stack name" do
     expected = query(:describe_stacks, %{"StackName" => "test_stack"})
-    assert expected == Cloudformation.describe_stacks("test_stack")
-  end
-
-  test "describe_stacks with blank name" do
-    expected = query(:describe_stacks, %{})
-    assert expected == Cloudformation.describe_stacks("")
+    assert expected == Cloudformation.describe_stacks([stack_name: "test_stack"])
   end
 
   test "describe_stacks with no name" do
     expected = query(:describe_stacks, %{})
-    assert expected == Cloudformation.describe_stacks()
+    assert expected == Cloudformation.describe_stacks
   end
 
   defp query(action, params \\ %{}) do

--- a/test/lib/ex_aws/utils_test.exs
+++ b/test/lib/ex_aws/utils_test.exs
@@ -25,6 +25,11 @@ defmodule ExAws.UtilsTest do
     |> camelize_keys(deep: true)
   end
 
+  test "camelize_keys spec works for non-standard keys" do
+    assert %{"non-standard" => ["foo", "bar"]} == [foo_bar: ["foo", "bar"]]
+    |> camelize_keys(spec: %{foo_bar: "non-standard"})
+  end
+
   test "iso_z_to_secs converts iso string to epoch seconds" do
     assert 1436134578 == iso_z_to_secs("2015-07-05T22:16:18Z")
   end
@@ -33,24 +38,31 @@ defmodule ExAws.UtilsTest do
     assert [d: 1, b: 2, e: 3] == [a: 1, b: 2, c: 3] |> rename_keys(a: :d, c: :e)
   end
 
+  test "flatten_params creates single key value pair" do
+    assert [{"Key", 1}] == flatten_params(key: 1)
+  end
+
   test "build_indexed_params creates key value pairs from key_template and list" do
-    assert [{"key.1", 1}, {"key.2", 2}] == build_indexed_params("key.{i}", [1,2])
+    assert [{"Key.1", 1}, {"Key.2", 2}] == flatten_params(key: [1,2])
   end
 
-  test "build_indexed_params creates key value pair from key_template and single element" do
-    assert [{"key.1", 1}] == build_indexed_params("key.{i}", 1)
+  test "build_indexed_params spec works for non-standard keys" do
+    assert [{"non-standard.1", 1}, {"non-standard.2", 2}] == flatten_params([foo_bar: [1,2]], spec: %{foo_bar: "non-standard"} )
   end
 
-  test "build_indexed_params creates key value pairs from list of key_templates" do
+  test "flatten_params creates key value pairs from list of key_templates" do
     expected_return = [
-        {"foo.1", 1}, {"foo.2", 2}, 
-        {"bar.1", 3}, {"bar.2", 4},
-      ]
-    index_params = build_indexed_params([ 
-        {"foo.{i}", [1,2]}, 
-        {"bar.{i}", [3,4]},
-      ])
-
-    assert expected_return == index_params
+      {"Tag.1.Key", "keyA"}, {"Tag.1.Value", "ValueA"},
+      {"Tag.2.Key", "keyB"}, {"Tag.2.Value", "keyB"},
+      {"Member", "member!"}
+    ]
+    
+    assert expected_return == flatten_params([
+      tag: [ 
+        [key: "keyA", value: "ValueA"], 
+        [key: "keyB", value: "keyB"],
+      ],
+      member: "member!"
+    ])
   end
 end

--- a/test/lib/ex_aws/utils_test.exs
+++ b/test/lib/ex_aws/utils_test.exs
@@ -38,31 +38,32 @@ defmodule ExAws.UtilsTest do
     assert [d: 1, b: 2, e: 3] == [a: 1, b: 2, c: 3] |> rename_keys(a: :d, c: :e)
   end
 
-  test "flatten_params creates single key value pair" do
-    assert [{"Key", 1}] == flatten_params(key: 1)
+  test "format (:xml) creates single key value pair" do
+    assert [{"Key", 1}] == format([key: 1], type: :xml)
   end
 
-  test "build_indexed_params creates key value pairs from key_template and list" do
-    assert [{"Key.1", 1}, {"Key.2", 2}] == flatten_params(key: [1,2])
+  test "format (:xml) creates key value pairs from key_template and list" do
+    assert [{"Key.1", 1}, {"Key.2", 2}] == format([key: [1,2]], type: :xml)
   end
 
-  test "build_indexed_params spec works for non-standard keys" do
-    assert [{"non-standard.1", 1}, {"non-standard.2", 2}] == flatten_params([foo_bar: [1,2]], spec: %{foo_bar: "non-standard"} )
+  test "format (:xml) spec works for non-standard keys" do
+    assert [{"non-standard.1", 1}, {"non-standard.2", 2}] == format(
+      [foo_bar: [1,2]], spec: %{foo_bar: "non-standard"}, type: :xml)
   end
 
-  test "flatten_params creates key value pairs from list of key_templates" do
+  test "format (:xml) creates key value pairs from list of key_templates" do
     expected_return = [
       {"Tag.1.Key", "keyA"}, {"Tag.1.Value", "ValueA"},
       {"Tag.2.Key", "keyB"}, {"Tag.2.Value", "keyB"},
       {"Member", "member!"}
     ]
     
-    assert expected_return == flatten_params([
+    assert expected_return == format([
       tag: [ 
         [key: "keyA", value: "ValueA"], 
         [key: "keyB", value: "keyB"],
       ],
       member: "member!"
-    ])
+    ], type: :xml)
   end
 end


### PR DESCRIPTION
General cleanup of the cloudformation module, and changed to the relevant utils. Including 

- Additional documentation for cloudformation
- Better overall naming of cloudformation's new functions
- Renamed cloudformation's private `transform` functions to `format_param` 
- Refactored Utils.build_indexed_params to flatten_params. Now recursive, making for more concise usage. 
- Refactored `format_param` functions to use new Utils.flatten_params
- Added `Utils.maybe_format` macro. A very simple macro for calling private `format_param` functions if the param isn't null.
- Added `Utils.maybe_camelize` and `Utils.maybe_stringify` to reduce atom and string checking clutter
- Added `__using__` macro to `Utils` for basic `import + require`

