### PR TITLE
add sts methods: assume role, decode_authorization_message, get_session_token

### DIFF
--- a/lib/ex_aws/sts.ex
+++ b/lib/ex_aws/sts.ex
@@ -10,6 +10,30 @@ defmodule ExAws.STS do
     binary => :all
   }
 
+  @type assume_role_opt ::
+    {:duration, pos_integer} |
+    {:serial_number, binary} |
+    {:token_code, binary}    |
+    {:external_id, binary}   |
+    {:policy, policy}
+
+  @doc "Assume Role"
+  @spec assume_role(role_arn :: String.t, role_session_name :: String.t, [assume_role_opt]) :: ExAws.Operation.Query.t
+  def assume_role(role_arn, role_name, opts \\ []) do
+    params = parse_opts(opts)
+    |> Map.put("RoleArn", role_arn)
+    |> Map.put("RoleSessionName", role_name)
+
+    request(:assume_role, params)
+  end
+
+  @doc "Decode Authorization Message"
+  @spec decode_authorization_message(message :: String.t) :: ExAws.Operation.Query.t
+  def decode_authorization_message(message) do
+    request(:decode_authorization_message, %{"EncodedMessage" => message})
+  end
+
+  @doc "Get Caller Identity"
   def get_caller_identity() do
     request(:get_caller_identity, %{})
   end
@@ -18,16 +42,26 @@ defmodule ExAws.STS do
 
   @doc "Get Federation Token"
   @spec get_federation_token(name :: String.t, [get_federation_token_opt]) :: ExAws.Operation.Query.t
-  def get_federation_token(name, opts) do
-    params =
-      %{
-        "Name" => name,
-      }
-      |> maybe_add_duration(opts)
-      |> maybe_add_policy(opts)
+  def get_federation_token(name, opts \\ []) do
+    params = parse_opts(opts)
+    |> Map.put("Name", name)
 
     request(:get_federation_token, params)
   end
+
+  @type get_session_token_opt ::
+    {:duration, pos_integer} |
+    {:serial_number, binary} |
+    {:token_code, binary}
+
+  @doc "Get Session Token"
+  @spec get_session_token([get_session_token_opt]) :: ExAws.Operation.Query.t
+  def get_session_token(opts \\ []) do
+    params = parse_opts(opts)
+
+    request(:get_session_token, params)
+  end
+
 
   ## Request
   ######################
@@ -49,21 +83,12 @@ defmodule ExAws.STS do
     }
   end
 
-  defp maybe_add_duration(params, opts) do
-    if Keyword.has_key?(opts, :duration) do
-      Map.merge(params, %{"DurationSeconds" => opts[:duration]})
-    else
-      params
-    end
+  defp parse_opts(opts) do
+    Enum.reduce(opts, %{}, fn item, acc -> parse_opt(acc, item) end)
   end
 
-  defp maybe_add_policy(params, opts) do
-    if Keyword.has_key?(opts, :policy) do
-      encoded_policy = Poison.encode!(opts[:policy])
-
-      Map.merge(params, %{"Policy" => encoded_policy})
-    else
-      params
-    end
-  end
+  defp parse_opt(opts, {:duration, val}), do: Map.put(opts, "DurationSeconds", val)
+  defp parse_opt(opts, {:token_code, val}), do: Map.put(opts, "TokenCode", val)
+  defp parse_opt(opts, {:serial_number, val}), do: Map.put(opts, "SerialNumber", val)
+  defp parse_opt(opts, {:policy, val}), do: Map.put(opts, "Policy", Poison.encode!(val))
 end

--- a/lib/ex_aws/sts/parsers.ex
+++ b/lib/ex_aws/sts/parsers.ex
@@ -2,6 +2,30 @@ if Code.ensure_loaded?(SweetXml) do
   defmodule ExAws.STS.Parsers do
     import SweetXml, only: [sigil_x: 2]
 
+    def parse({:ok, %{body: xml}=resp}, :assume_role) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//AssumeRoleResponse",
+                        access_key_id: ~x"./AssumeRoleResult/Credentials/AccessKeyId/text()"s,
+                        secret_access_key: ~x"./AssumeRoleResult/Credentials/SecretAccessKey/text()"s,
+                        session_token: ~x"./AssumeRoleResult/Credentials/SessionToken/text()"s,
+                        expiration: ~x"./AssumeRoleResult/Credentials/Expiration/text()"s,
+                        assumed_role_id: ~x"./AssumeRoleResult/AssumedRoleUser/AssumedRoleId/text()"s,
+                        assumed_role_arn: ~x"./AssumeRoleResult/AssumedRoleUser/Arn/text()"s,
+                        request_id: request_id_xpath())
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
+    def parse({:ok, %{body: xml}=resp}, :decode_authorization_message) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//DecodeAuthorizationMessageResponse",
+                        decoded_message: ~x"./DecodeAuthorizationMessageResult/DecodedMessage/text()"s,
+                        request_id: request_id_xpath())
+      |> Map.update!(:decoded_message, &Poison.decode!/1)
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
     def parse({:ok, %{body: xml} = resp}, :get_caller_identity) do
       parsed_body = SweetXml.xpath(xml, ~x"//GetCallerIdentityResponse", [
         arn: ~x"./GetCallerIdentityResult/Arn/text()"s,
@@ -20,6 +44,18 @@ if Code.ensure_loaded?(SweetXml) do
                         secret_access_key: ~x"./GetFederationTokenResult/Credentials/SecretAccessKey/text()"s,
                         session_token: ~x"./GetFederationTokenResult/Credentials/SessionToken/text()"s,
                         expiration: ~x"./GetFederationTokenResult/Credentials/Expiration/text()"s,
+                        request_id: request_id_xpath())
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
+    def parse({:ok, %{body: xml}=resp}, :get_session_token) do
+      parsed_body = xml
+      |> SweetXml.xpath(~x"//GetSessionTokenResponse",
+                        access_key_id: ~x"./GetSessionTokenResult/Credentials/AccessKeyId/text()"s,
+                        secret_access_key: ~x"./GetSessionTokenResult/Credentials/SecretAccessKey/text()"s,
+                        session_token: ~x"./GetSessionTokenResult/Credentials/SessionToken/text()"s,
+                        expiration: ~x"./GetSessionTokenResult/Credentials/Expiration/text()"s,
                         request_id: request_id_xpath())
 
       {:ok, Map.put(resp, :body, parsed_body)}

--- a/test/lib/ex_aws/sts_test.exs
+++ b/test/lib/ex_aws/sts_test.exs
@@ -8,6 +8,34 @@ defmodule ExAws.STSTest do
     assert {:ok, %{body: %{account: _}}} = result
   end
 
+  test "#assume_role" do
+    version = "2011-06-15"
+    arn = "1111111/test_role"
+    name = "test role"
+    expected = %{
+      "Action" => "AssumeRole",
+      "RoleSessionName" => name,
+      "RoleArn" => arn,
+      "Version" => version,
+    }
+
+    assert expected == STS.assume_role(arn, name).params
+  end
+
+
+  test "#decode_authorization_message" do
+    version = "2011-06-15"
+    message = "msgcontent"
+    expected = %{
+      "Action" => "DecodeAuthorizationMessage",
+      "EncodedMessage" => message,
+      "Version" => version,
+    }
+
+    assert expected == STS.decode_authorization_message(message).params
+  end
+
+
   test "#get_federation_token" do
     version = "2011-06-15"
     duration = 900
@@ -35,4 +63,18 @@ defmodule ExAws.STSTest do
 
     assert expected == STS.get_federation_token(name, opts).params
   end
+
+  test "#get_session_token" do
+    version = "2011-06-15"
+    duration = 900
+
+    expected = %{
+      "Action" => "GetSessionToken",
+      "DurationSeconds" => duration,
+      "Version" => version,
+    }
+
+    assert expected == STS.get_session_token([duration: duration]).params
+  end
+
 end


### PR DESCRIPTION
Some services don't allow cross-account permissions without using AssumeRole. 

While I was in there I added two other missing methods - DecodeAuthorizationMessage and GetSessionToken. 

This still leaves two missing methods:
AssumeRoleWithSAML
AssumeRoleWithWebIdentity

I can't see any use for WebIdentity in elixir, as it is designed for mobile app authentication. The SAML method would be very difficult to test, and they don't even provide sample request/response data on that doc. I'd rather err on the side of caution and not include them, but certainly could if that's preferred.