### PR TITLE
Added (deprecated) support for :status_filter param

### DIFF
--- a/lib/ex_aws/cloudformation.ex
+++ b/lib/ex_aws/cloudformation.ex
@@ -56,7 +56,8 @@ defmodule ExAws.Cloudformation do
     use_previous_value: boolean
   ]
 
-  @type tag :: {key :: atom, value :: binary}
+  @type tag :: 
+    {key :: atom | binary, value :: binary}
 
   @doc """
   Cancels an update on the specified stack.
@@ -359,6 +360,17 @@ defmodule ExAws.Cloudformation do
     |> format(prefix: "StackStatusFilter.member")
   end
 
+  # TODO !deprecated! Remove in 1.2
+  defp format_param({:status_filter, filters}) do
+    IO.warn(
+      "(ExAws.Cloudformation) The :status_filter param is DEPRECATED! Please use :stack_status_filters instead
+        For example: list_stacks(status_filter: [...]) should be changed to list_stacks(stack_status_filters: [...])"
+    )
+    format_param({:stack_status_filters, filters})
+  end
+  # TODO !deprecated! Remove in 1.2
+
+
   defp format_param({:capabilities, capabilities}) do
     capabilities
     |> Enum.map(&upcase/1)
@@ -367,7 +379,7 @@ defmodule ExAws.Cloudformation do
 
   defp format_param({:tags, tags}) do
     tags
-    |> Enum.map(fn {key, value} -> [key: Atom.to_string(key), value: value] end)
+    |> Enum.map(fn {key, value} -> [key: maybe_stringify(key), value: value] end)
     |> format(prefix: "Tags.member")
   end
 

--- a/test/lib/ex_aws/cloudformation/integration_test.exs
+++ b/test/lib/ex_aws/cloudformation/integration_test.exs
@@ -2,7 +2,7 @@ defmodule ExAws.CloudformationIntegrationTest do
   use ExUnit.Case, async: true
 
   test "list_stacks works" do
-    assert {:ok, %{body: %{stacks: _}}} = ExAws.Cloudformation.list_stacks(status_filter: [:update_complete, :create_complete]) |> ExAws.request
+    assert {:ok, %{body: %{stacks: _}}} = ExAws.Cloudformation.list_stacks(stack_status_filters: [:update_complete, :create_complete]) |> ExAws.request
   end
 
   test "describe_stacks works" do

--- a/test/lib/ex_aws/cloudformation_test.exs
+++ b/test/lib/ex_aws/cloudformation_test.exs
@@ -89,6 +89,8 @@ defmodule ExAws.CloudformationTest do
 
     assert expected == Cloudformation.create_stack("test_stack",
     [tags: [key: "value"]])
+    assert expected == Cloudformation.create_stack("test_stack",
+    [tags: [ {"key", "value"} ]])
   end
 
   test "create_stack with capabilities" do


### PR DESCRIPTION
One Cloudformation integration test was failing due to using the `:status_filter` param instead of the updated  `:stack_status_filters`. This was changed because `:status_filter` doesn't match the AWS spec `StackStatusFilter`.  And doesn't match `ExAws.Cloudformation`'s own naming convention of pluralizing params that require lists. (for example `stack_status_filters: [...]`)

In addition to fixing the integration test, support for the old `:status_filter` param has been readded with a deprecated warning. This function should be removed in 1.2. 