### PR TITLE
Make `use ExAws.Utils` expanded functions private

### DIFF
--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -11,7 +11,7 @@ defmodule ExAws.Utils do
     deep = kwargs[:deep] || false
     spec = kwargs[:spec] || %{}
     do_cmlz_keys(opts, deep: deep, spec: spec)
-  end 
+  end
 
   defp do_cmlz_keys([%{} | _] = opts, deep: deep, spec: spec) do
     Enum.map(opts, &do_cmlz_keys(&1, deep: deep, spec: spec))
@@ -41,16 +41,16 @@ defmodule ExAws.Utils do
 
   def camelize(string) do
     string
-    |> to_charlist 
-    |> Enum.reduce({true, ''}, fn 
+    |> to_charlist
+    |> Enum.reduce({true, ''}, fn
       ?_ , {_, acc} -> {true, acc}
       ?/ , {_, acc} -> {false, [?. | acc]}
       char, {false, acc} -> {false, [char | acc]}
       char, {true, acc}  -> {false, [upcase(char) | acc]}
-    end) 
+    end)
     |> elem(1) # charlist
-    |> Enum.reverse # unreverses charlist after reducing 
-    |> to_string 
+    |> Enum.reverse # unreverses charlist after reducing
+    |> to_string
   end
 
   def upcase(value) when is_atom(value), do: value |> Atom.to_string |> String.upcase
@@ -89,7 +89,7 @@ defmodule ExAws.Utils do
     Enum.map(params, fn {k, v} ->
       {Map.get(mapping, k, k), v}
     end)
-  end 
+  end
 
   def format(params, kwargs \\ []) do
     prefix = kwargs[:prefix] || ""
@@ -100,10 +100,10 @@ defmodule ExAws.Utils do
     end
   end
 
-  # NOTE: xml_format is not tail call optimized 
+  # NOTE: xml_format is not tail call optimized
   # but it is unlikely that any AWS params will ever
   # be nested enough for this to  cause a stack overflow
-  
+
   # Indexed formats
 
   defp xml_format([ nested | _ ] = params, kwargs) when is_map(nested) do
@@ -115,8 +115,8 @@ defmodule ExAws.Utils do
     params
     |> Stream.with_index(1)
     |> Stream.map(fn {params, i} -> {params, Integer.to_string(i)} end)
-    |> Stream.flat_map(fn {params, i} -> 
-      xml_format(params, prefix: pre <> dot?(pre) <> i, spec: spec) 
+    |> Stream.flat_map(fn {params, i} ->
+      xml_format(params, prefix: pre <> dot?(pre) <> i, spec: spec)
     end)
     |> Enum.to_list
   end
@@ -125,8 +125,8 @@ defmodule ExAws.Utils do
     # IO.inspect("prefixed")
     params
     |> Stream.map(fn {key, values} -> {maybe_camelize(key, spec: spec), values} end)
-    |> Stream.flat_map(fn {key, values} -> 
-      xml_format(values, prefix: pre <> dot?(pre) <> key, spec: spec) 
+    |> Stream.flat_map(fn {key, values} ->
+      xml_format(values, prefix: pre <> dot?(pre) <> key, spec: spec)
     end)
     |> Enum.to_list
   end
@@ -147,7 +147,7 @@ defmodule ExAws.Utils do
   end
 
   defp xml_format(value, kwargs), do: [{kwargs[:prefix], value}]
-  
+
   defp dot?(""), do: ""
   defp dot?(_), do: "."
 
@@ -165,27 +165,27 @@ defmodule ExAws.Utils do
   def maybe_stringify(elem) when is_bitstring(elem), do: elem
 
   defmacro __using__(kwargs) do
-    camelize_inject = quote do 
-        [  spec: unquote(kwargs[:non_standard_keys] || %{}) ] 
-        ++ kwargs 
+    camelize_inject = quote do
+        [  spec: unquote(kwargs[:non_standard_keys] || %{}) ]
+        ++ kwargs
       end
-    format_inject = quote do 
+    format_inject = quote do
         [ type: unquote(kwargs[:format_type] || :xml)]
-        ++ unquote(camelize_inject) 
+        ++ unquote(camelize_inject)
       end
 
     quote do
       import ExAws.Utils, except: [
-        format: 2, format: 1,  
-        camelize_keys: 2, camelize_keys: 1, 
+        format: 2, format: 1,
+        camelize_keys: 2, camelize_keys: 1,
         camelize_key: 2, camelize_key: 1,
-        maybe_camelize: 2, maybe_camelize: 1 
+        maybe_camelize: 2, maybe_camelize: 1
       ]
 
-      def format(params, kwargs \\ []), do: ExAws.Utils.format(params, unquote(format_inject))
-      def camelize_keys(opts, kwargs \\ []), do: ExAws.Utils.camelize_keys(opts, unquote(camelize_inject))
-      def camelize_key(opts, kwargs \\ []), do: ExAws.Utils.camelize_key(opts, unquote(camelize_inject))
-      def maybe_camelize(opts, kwargs \\ []), do: ExAws.Utils.maybe_camelize(opts, unquote(camelize_inject))
+      defp format(params, kwargs \\ []), do: ExAws.Utils.format(params, unquote(format_inject))
+      defp camelize_keys(opts, kwargs \\ []), do: ExAws.Utils.camelize_keys(opts, unquote(camelize_inject))
+      defp camelize_key(opts, kwargs \\ []), do: ExAws.Utils.camelize_key(opts, unquote(camelize_inject))
+      defp maybe_camelize(opts, kwargs \\ []), do: ExAws.Utils.maybe_camelize(opts, unquote(camelize_inject))
     end
   end
 end


### PR DESCRIPTION
`use ExAws.Utils` expands to four partially applied Util functions with `:non_standard_keys` and `:format_type` automatically applied to every relevant Util function. This is very useful for removing some unnecessary, and hard to read code. 

Unforchenetly our implementation of `Utils.__using__` was adding public functions. We were foreseeing a possible use-case where having `Cloudformation.format` be public would be useful. But we neglected to think about the documentation. 

While there is no downside from an encapsulation standpoint, it clutters the documentation with functions that the end user doesn't need to know about. This pull request changes the functions to be private.

There are other ways of addressing the above-mentioned usecase that don't have this downside. So this is probably a good ide.a 