### PR TITLE
[bug fix] camelize values of Lambda.invoke() options :invocation_type and  :log_type

### DIFF
--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -3,7 +3,7 @@ defmodule ExAws.Lambda do
   Operations on ExAws Lambda
   """
 
-  import ExAws.Utils, only: [camelize_keys: 1, upcase: 1]
+  import ExAws.Utils, only: [camelize_key: 1, camelize_keys: 1, upcase: 1]
   require Logger
 
   @actions %{
@@ -167,7 +167,7 @@ defmodule ExAws.Lambda do
       case Map.fetch(opts, opt) do
         :error       -> headers
         {:ok, nil}   -> headers
-        {:ok, value} -> [{header, value} | headers]
+        {:ok, value} -> [{header, value |> camelize_key} | headers]
       end
     end)
 


### PR DESCRIPTION
Given the type spec:

```
 @doc "Invoke a lambda function"
 @type invoke_opts :: [
    {:invocation_type, :event | :request_response | :dry_run} |
    {:log_type, :none | :tail} |
    {:qualifier, String.t}
  ]
```

we should convert all the options values to the AWS expected format, ie:

- Event, RequestResponse, DryRun
- None, Tail

This is the error raised by the AWS Lambda subsystem:

```
iex(2)> ExAws.Lambda.invoke("echo", %{}, %{}, invocation_type: :dry_run) |> ExAws.request
{:error,
 {:http_error, 400,
  %{body: "{\"message\":\"1 validation error detected: Value 'dry_run' at 'invocationType' failed to satisfy constraint: Member must satisfy enum value set: [DryRun, RequestResponse, Event]\"}",
    headers: [{"Content-Type", "application/json"},
     {"Date", "Sun, 02 Jul 2017 11:28:05 GMT"},
     {"x-amzn-ErrorType", "ValidationException"},
     {"x-amzn-RequestId", "8451e543-xxxx-11e7-xxxx-87dcc9c858fc"},
     {"Content-Length", "177"}, {"Connection", "keep-alive"}],
    status_code: 400}}}
```