### PR TITLE
Gets rid of unused variables warning.

### DIFF
--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -270,7 +270,7 @@ if Code.ensure_loaded?(SweetXml) do
   end
 else
   defmodule ExAws.SQS.Parsers do
-    def parse(val, _), do: raise ExAws.Error, "Missing XML parser. Please see docs"
+    def parse(_val, _), do: raise ExAws.Error, "Missing XML parser. Please see docs"
 
   end
 end


### PR DESCRIPTION
Gets rid of the following warning:
```
warning: variable "val" is unused
  lib/ex_aws/sqs/parsers.ex:273
```