### PR TITLE
Detect error in instance_meta HTTP GET request

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -14,8 +14,14 @@ defmodule ExAws.InstanceMeta do
 
   def request(config, url) do
     case config.http_client.request(:get, url) do
-      {:ok, %{body: body}} ->
+      {:ok, %{status_code: 200, body: body}} ->
         body
+      {:ok, %{status_code: status_code}} ->
+        raise """
+        Instance Meta Error: HTTP response status code #{inspect status_code}
+
+        Please check AWS EC2 IAM role.
+        """
       error ->
         raise """
         Instance Meta Error: #{inspect error}


### PR DESCRIPTION
For example, if the EC2 instance has no IAM Role attached the response is "404 not found".