### PR TITLE
Feature/put object iodata

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -14,8 +14,14 @@ defmodule ExAws.InstanceMeta do
 
   def request(config, url) do
     case config.http_client.request(:get, url) do
-      {:ok, %{body: body}} ->
+      {:ok, %{status_code: 200, body: body}} ->
         body
+      {:ok, %{status_code: status_code}} ->
+        raise """
+        Instance Meta Error: HTTP response status code #{inspect status_code}
+
+        Please check AWS EC2 IAM role.
+        """
       error ->
         raise """
         Instance Meta Error: #{inspect error}

--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -34,7 +34,7 @@ defmodule ExAws.Operation.S3 do
 
       headers = headers
       |> Map.put("x-amz-content-sha256", hashed_payload)
-      |> Map.put("content-length", byte_size(body))
+      |> Map.put("content-length", :erlang.iolist_size(body))
       |> Map.to_list
 
       ExAws.Request.request(http_method, url, body, headers, config, operation.service)

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -12,10 +12,11 @@ defmodule ExAws.Request do
   @type response_t :: success_t | error_t
 
   def request(http_method, url, data, headers, config, service) do
-    body = case data do
-      []  -> "{}"
-      d when is_binary(d) -> d
-      _   -> config[:json_codec].encode!(data)
+    body = cond do
+      data == [] -> "{}"
+      is_binary(data) -> data
+      config[:no_encode] == true -> data
+      true -> config[:json_codec].encode!(data)
     end
 
     request_and_retry(http_method, url, service, config, headers, body, {:attempt, 1})

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -31,6 +31,30 @@ defmodule ExAws.S3Test do
     )
   end
 
+  test "#put_object with iodata" do
+    expected = %Operation.S3{
+      body: [1, 2, 3, 4, 5], bucket: "bucket",
+      headers: %{
+        "content-encoding" => "application/json",
+        "x-amz-acl" => "public-read",
+        "x-amz-server-side-encryption" => "AES256",
+        "x-amz-storage-class" => "spicy",
+        "content-md5" => "asdf",
+        "x-amz-meta-foo" => "sqiggles"},
+      path: "object.json",
+      http_method: :put
+    }
+
+    assert expected == S3.put_object("bucket", "object.json", [1, 2, 3, 4, 5],
+      content_encoding: "application/json",
+      storage_class: "spicy",
+      content_md5: "asdf",
+      acl: :public_read,
+      encryption: "AES256",
+      meta: [foo: "sqiggles"]
+    )
+  end
+
   test "#put_bucket with non-us-east-1 region" do
     region = "not-us-east-1"
     bucket = "new.bucket"


### PR DESCRIPTION
Addresses #305  but...

There didn't seem to be any test coverage for the current implementation and, when in Rome, ... I did manually test it.

Also, as far as I can tell, the `no_encode: true` option is necessary to maintain backwards compatibility.