### PR TITLE
fix @spec for map() type

### DIFF
--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -156,8 +156,8 @@ defmodule ExAws.Lambda do
     {:log_type, :none | :tail} |
     {:qualifier, String.t}
   ]
-  @spec invoke(function_name :: binary, payload :: %{}, client_context :: %{}) :: ExAws.Operation.JSON.t
-  @spec invoke(function_name :: binary, payload :: %{}, client_context :: %{}, opts :: invoke_opts) :: ExAws.Operation.JSON.t
+  @spec invoke(function_name :: binary, payload :: map(), client_context :: map()) :: ExAws.Operation.JSON.t
+  @spec invoke(function_name :: binary, payload :: map(), client_context :: map(), opts :: invoke_opts) :: ExAws.Operation.JSON.t
   @context_header "X-Amz-Client-Context"
   def invoke(function_name, payload, client_context, opts \\ []) do
     {qualifier, opts} = Map.pop(Enum.into(opts, %{}), :qualifier)
@@ -198,7 +198,7 @@ defmodule ExAws.Lambda do
   end
 
   @doc "Invoke a lambda function asynchronously"
-  @spec invoke_async(function_name :: binary, args :: %{}) :: ExAws.Operation.JSON.t
+  @spec invoke_async(function_name :: binary, args :: map()) :: ExAws.Operation.JSON.t
   def invoke_async(function_name, args) do
     Logger.info("This API is deprecated. See invoke/5 with the Event value set as invocation type")
     request(:invoke, args |> normalize_opts, "/2014-11-13/functions/#{function_name}/invoke-async/")
@@ -238,7 +238,7 @@ defmodule ExAws.Lambda do
   end
 
   @doc "Update event source mapping"
-  @spec update_event_source_mapping(uuid :: binary, attrs_to_update :: %{}) :: ExAws.Operation.JSON.t
+  @spec update_event_source_mapping(uuid :: binary, attrs_to_update :: map()) :: ExAws.Operation.JSON.t
   def update_event_source_mapping(uuid, attrs_to_update) do
     request(:update_event_source_mapping, attrs_to_update, "/2015-03-31/event-source-mappings/#{uuid}")
   end
@@ -251,7 +251,7 @@ defmodule ExAws.Lambda do
   end
 
   @doc "Update a function configuration"
-  @spec update_function_configuration(function_name :: binary, configuration :: %{}) :: ExAws.Operation.JSON.t
+  @spec update_function_configuration(function_name :: binary, configuration :: map()) :: ExAws.Operation.JSON.t
   def update_function_configuration(function_name, configuration) do
     data = configuration |> normalize_opts
     request(:update_function_configuration, data, "/2015-03-31/functions/#{function_name}/versions/HEAD/configuration")

--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -292,7 +292,7 @@ defmodule ExAws.S3 do
   end
 
   @doc "Update or create a bucket CORS policy"
-  @spec put_bucket_cors(bucket :: binary, cors_config :: %{}) :: ExAws.Operation.S3.t
+  @spec put_bucket_cors(bucket :: binary, cors_config :: map()) :: ExAws.Operation.S3.t
   def put_bucket_cors(bucket, cors_rules) do
     rules = cors_rules
     |> Enum.map(&build_cors_rule/1)
@@ -307,41 +307,41 @@ defmodule ExAws.S3 do
   end
 
   @doc "Update or create a bucket lifecycle configuration"
-  @spec put_bucket_lifecycle(bucket :: binary, lifecycle_config :: %{}) :: no_return
+  @spec put_bucket_lifecycle(bucket :: binary, lifecycle_config :: map()) :: no_return
   def put_bucket_lifecycle(bucket, _livecycle_config) do
     raise "not yet implemented"
     request(:put, bucket, "/")
   end
 
   @doc "Update or create a bucket policy configuration"
-  @spec put_bucket_policy(bucket :: binary, policy :: %{}) :: ExAws.Operation.S3.t
+  @spec put_bucket_policy(bucket :: binary, policy :: map()) :: ExAws.Operation.S3.t
   def put_bucket_policy(bucket, policy) do
     request(:put, bucket, "/", resource: "policy", body: policy)
   end
 
   @doc "Update or create a bucket logging configuration"
-  @spec put_bucket_logging(bucket :: binary, logging_config :: %{}) :: no_return
+  @spec put_bucket_logging(bucket :: binary, logging_config :: map()) :: no_return
   def put_bucket_logging(bucket, _logging_config) do
     raise "not yet implemented"
     request(:put, bucket, "/")
   end
 
   @doc "Update or create a bucket notification configuration"
-  @spec put_bucket_notification(bucket :: binary, notification_config :: %{}) :: no_return
+  @spec put_bucket_notification(bucket :: binary, notification_config :: map()) :: no_return
   def put_bucket_notification(bucket, _notification_config) do
     raise "not yet implemented"
     request(:put, bucket, "/")
   end
 
   @doc "Update or create a bucket replication configuration"
-  @spec put_bucket_replication(bucket :: binary, replication_config :: %{}) :: no_return
+  @spec put_bucket_replication(bucket :: binary, replication_config :: map()) :: no_return
   def put_bucket_replication(bucket, _replication_config) do
     raise "not yet implemented"
     request(:put, bucket, "/")
   end
 
   @doc "Update or create a bucket tagging configuration"
-  @spec put_bucket_tagging(bucket :: binary, tags :: %{}) :: no_return
+  @spec put_bucket_tagging(bucket :: binary, tags :: map()) :: no_return
   def put_bucket_tagging(bucket, _tags) do
     raise "not yet implemented"
     request(:put, bucket, "/")


### PR DESCRIPTION
Some fixes to **spec for map()** type.

> the syntactic representation of map() is %{optional(any) => any}, not %{}. The notation %{} specifies the singleton type for the empty map.

PS: I see there is no dialyzer step in your travis build. Currently dialyzer reports about 19 warning. I think could be useful to fix those and add a dialyzer step in travis to find immediately grey spots in new code.