### PR TITLE
Update request retry logging and add a logging section to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ config :ex_aws, :retries,
 
 ExAws does not include logging except through the `:debug_requests` option which logs the
 URL, headers, and body of _every_ request. As indicated by the name, it is recommeded for
-debugging and should _not_ be enabled for production environments. You can enable it via:
+debugging and should _not_ be used within production environments. You can enable it via:
 
 ```elixir
 config :ex_aws,
@@ -185,8 +185,9 @@ config :ex_aws,
 ```
 
 For production logging, we recommend something like
-[Timber](http://github.com/timberio/timber-elixir), which provides a custom HTTP client to
-thoughtfully log HTTP requests:
+[Timber](http://github.com/timberio/timber-elixir), which provides a
+[custom HTTP client](https://github.com/timberio/timber-elixir/blob/master/lib/timber/integrations/ex_aws_http_client.ex)
+to thoughtfully log HTTP requests:
 
 ```elixir
 config :ex_aws,

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ it would be encoded as an integer set. This had issues because if the list was
 `[1,2,1]` you could get an error because the items are not unique.
 
 ## Highlighted Features
+
 - Easy configuration.
 - Minimal dependencies. Choose your favorite JSON codec and HTTP client.
 - Elixir streams to automatically retrieve paginated resources.
@@ -150,6 +151,7 @@ config :ex_aws,
   access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role],
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, {:awscli, "default", 30}, :instance_role],
 ```
+
 ## Retries
 
 ExAws will retry failed AWS API requests using exponential backoff per the "Full
@@ -171,6 +173,25 @@ config :ex_aws, :retries,
 * `base_backoff_in_ms` corresponds to the `base` value described in the blog post
 * `max_backoff_in_ms` corresponds to the `cap` value described in the blog post
 
+## Logging
+
+ExAws does not include logging except through the `:debug_requests` option which logs the
+URL, headers, and body of _every_ request. As indicated by the name, it is recommeded for
+debugging and should _not_ be enabled for production environments. You can enable it via:
+
+```elixir
+config :ex_aws,
+  debug_requests: true
+```
+
+For production logging, we recommend something like
+[Timber](http://github.com/timberio/timber-elixir), which provides a custom HTTP client to
+thoughtfully log HTTP requests:
+
+```elixir
+config :ex_aws,
+  http_client: Timber.Integrations.ExAwsHTTPClient
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ config :ex_aws,
   debug_requests: true
 ```
 
-For production logging, we recommend something like
+For production logging, we recommend creating a custom HTTP client, something like
 [Timber](http://github.com/timberio/timber-elixir), which provides a
 [custom HTTP client](https://github.com/timberio/timber-elixir/blob/master/lib/timber/integrations/ex_aws_http_client.ex)
 to thoughtfully log HTTP requests:

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -60,7 +60,7 @@ defmodule ExAws.Request do
           else
             Logger.error("ExAws: HTTP ERROR: #{inspect reason}, failing")
           end
-          request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
+          request_and_retry(method, url, service, config, headers, req_body, attempt_again)
       end
     end
   end

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -47,13 +47,19 @@ defmodule ExAws.Request do
         {:ok, %{status_code: status, body: body}} when status >= 500 ->
           reason = {:http_error, status, body}
           attempt_again = attempt_again?(attempt, reason, config)
-          retrying_text = if attempt_again, do: ", retrying", else: ""
-          Logger.warn("ExAws: Bad response status #{status}#{retrying_text}")
+          if attempt_again do
+            Logger.warn("ExAws: Bad response status #{status}, retrying")
+          else
+            Logger.error("ExAws: Bad response status #{status}, failing")
+          end
           request_and_retry(method, url, service, config, headers, req_body, attempt_again)
         {:error, %{reason: reason}} ->
           attempt_again = attempt_again?(attempt, reason, config)
-          retrying_text = if attempt_again, do: ", retrying", else: ""
-          Logger.warn("ExAws: HTTP ERROR: #{inspect reason}#{retrying_text}")
+          if attempt_again do
+            Logger.warn("ExAws: HTTP ERROR: #{inspect reason}, retrying")
+          else
+            Logger.error("ExAws: HTTP ERROR: #{inspect reason}, failing")
+          end
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
       end
     end

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -46,9 +46,14 @@ defmodule ExAws.Request do
           end
         {:ok, %{status_code: status, body: body}} when status >= 500 ->
           reason = {:http_error, status, body}
-          request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
+          attempt_again = attempt_again?(attempt, reason, config)
+          retrying_text = if attempt_again, do: ", retrying", else: ""
+          Logger.warn("ExAws: Bad response status #{status}#{retrying_text}")
+          request_and_retry(method, url, service, config, headers, req_body, attempt_again)
         {:error, %{reason: reason}} ->
-          Logger.warn("ExAws: HTTP ERROR: #{inspect reason}")
+          attempt_again = attempt_again?(attempt, reason, config)
+          retrying_text = if attempt_again, do: ", retrying", else: ""
+          Logger.warn("ExAws: HTTP ERROR: #{inspect reason}#{retrying_text}")
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
       end
     end


### PR DESCRIPTION
Hi! First, thank you to everyone that spends time maintaining this library. We use it internally at Timber and would love to support this project in any way we can.

That said, we came across an issue where we needed to debug our interaction with the AWS API. It wasn't immediately clear that the `:debug_requests` option was available, or logging in general. This PR does a few things:

1. Adds a logging statement in the `Request` module to log when a bad response is encountered.
2. Moves the final/failed logging statement to `error` since that is a more appropriate level and helps with searching / alerting. We're a logging company :)
3. Adds a message in the logging statement to denote if the request is being retried or failing.
4. Adds a logging section in the readme to help save time for other users of this library. I also added a link to our custom HTTP client demonstrating how to extend ExAws to implement custom logging, and hopefully improve their experience with this library.