### PR TITLE
Support hackney versions >= 1.6 but < 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule ExAws.Mixfile do
       {:xml_builder, "~> 0.1.0", optional: true},
       {:sweet_xml, "~> 0.6", optional: true},
       {:ex_doc, "~> 0.16", only: :dev},
-      {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6", optional: true},
+      {:hackney, "~> 1.6", optional: true},
       {:poison, ">= 1.2.0", optional: true},
       {:jsx, "~> 2.8", optional: true},
       {:dialyze, "~> 0.2.0", only: :dev},


### PR DESCRIPTION
This simplifies the required hackney version, at the same time,
adds support for the newly released 1.9.0 version.