### PR TITLE
Tests: SQS.receive_message wrong argument name

### DIFF
--- a/test/lib/ex_aws/sqs_test.exs
+++ b/test/lib/ex_aws/sqs_test.exs
@@ -276,10 +276,10 @@ defmodule ExAws.SQSTest do
     assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: :all,
                                                                       max_number_of_messages: 5).params
 
-    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "SenderId", "AttributeName.2" => "ApproximateReceiveCount", "VisibilityTimeout" => 1000, "WaitTimeout" => 20}
+    expected = %{"Action" => "ReceiveMessage", "AttributeName.1" => "SenderId", "AttributeName.2" => "ApproximateReceiveCount", "VisibilityTimeout" => 1000, "WaitTimeSeconds" => 20}
     assert expected == SQS.receive_message("982071696186/test_queue", attribute_names: [:sender_id, :approximate_receive_count],
                                                                       visibility_timeout: 1000,
-                                                                      wait_timeout: 20).params
+                                                                      wait_time_seconds: 20).params
   end
 
   test "#receive_message can set the message attributes to all" do


### PR DESCRIPTION
Hello!
I found the wrong name of an argument while using tests as a source of SQS query samples - `wait_timeout` but it should be `wait_time_seconds`.
Thank you for your work!