### PR TITLE
Fixed Elixir 1.5 deprecation warnings

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -134,7 +134,7 @@ defmodule ExAws.Auth do
     #{Credentials.generate_credential_scope_v4(service, config, datetime)}
     #{request}
     """
-    |> String.rstrip
+    |> String.trim_leading()
   end
 
   defp signed_headers(headers) do
@@ -182,7 +182,7 @@ defmodule ExAws.Auth do
   defp canonical_headers(headers) do
     headers
     |> Enum.map(fn
-      {k, v} when is_binary(v) -> {String.downcase(k), String.strip(v)}
+      {k, v} when is_binary(v) -> {String.downcase(k), String.trim(v)}
       {k, v} -> {String.downcase(k), v}
     end)
     |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)


### PR DESCRIPTION
```
==> ex_aws
Compiling 61 files (.ex)
warning: String.rstrip/1 is deprecated, use String.trim_trailing/1
  lib/ex_aws/auth.ex:137

warning: String.strip/1 is deprecated, use String.trim/1
  lib/ex_aws/auth.ex:185

Generated ex_aws app
```