### PR TITLE
Add support for query params in S3 key names

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -61,7 +61,15 @@ defmodule ExAws.Auth do
       query_for_url = if Enum.any?(org_query_params), do: org_query <> "&" <> amz_query, else: amz_query
 
       uri = URI.parse(url)
-      path = uri_encode(uri.path)
+
+      path = if uri.query do
+        uri.path <> "?" <> uri.query
+      else
+        uri.path
+      end
+
+      path = uri_encode(path)
+
       signature = signature(http_method, path, query_to_sign, headers, nil, service, datetime, config)
       {:ok, "#{uri.scheme}://#{uri.authority}#{path}?#{query_for_url}&X-Amz-Signature=#{signature}"}
     end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -185,6 +185,11 @@ defmodule ExAws.S3Test do
     assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo/bar.txt", "3600")
   end
 
+  test "#presigned_url file is key with query params" do
+    {:ok, url} = S3.presigned_url(config(), :get, "bucket", "/foo/bar.txt?d=400")
+    assert_pre_signed_url(url, "https://s3.amazonaws.com/bucket/foo/bar.txt%3Fd%3D400", "3600")
+  end
+
   test "#presigned_url raises exception on bad expires_in option" do
     opts = [expires_in: 60 * 60 * 24 * 8]
     {:error, reason} = S3.presigned_url(config(), :get, "bucket", "foo.txt", opts)


### PR DESCRIPTION
AWS supports ? in key names however the way we were previously encoding
the URL to be signed caused these query params to be dropped.

For more info on what S3 supports in keys see:
http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys