### PR TITLE
Fix presigned URL port handling

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -891,10 +891,11 @@ defmodule ExAws.S3 do
   end
 
   defp url_to_sign(bucket, object, config, virtual_host) do
+    port = sanitized_port_component(config)
     object = ensure_slash(object)
     case virtual_host do
-      true -> "#{config[:scheme]}#{bucket}.#{config[:host]}#{object}"
-      false -> "#{config[:scheme]}#{config[:host]}/#{bucket}#{object}"
+      true -> "#{config[:scheme]}#{bucket}.#{config[:host]}#{port}#{object}"
+      false -> "#{config[:scheme]}#{config[:host]}#{port}/#{bucket}#{object}"
     end
   end
 

--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -138,4 +138,12 @@ defmodule ExAws.S3.Utils do
     |> Enum.map(fn {k ,v} -> {normalize_param(k), v} end)
     |> namespace("x-amz-server-side-encryption")
   end
+
+  # If we're using a standard port such as 80 or 443, then it needs to be excluded from the signed
+  # headers. Including standard ports will cause AWS's signature validation to fail with a
+  # SignatureDoesNotMatch error.
+  @excluded_ports [80, "80", 443, "443"]
+  def sanitized_port_component(%{port: nil}), do: ""
+  def sanitized_port_component(%{port: port}) when port in @excluded_ports, do: ""
+  def sanitized_port_component(%{port: port}), do: ":#{port}"
 end

--- a/test/lib/ex_aws/s3_test.exs
+++ b/test/lib/ex_aws/s3_test.exs
@@ -191,6 +191,13 @@ defmodule ExAws.S3Test do
     assert "expires_in_exceeds_one_week" == reason
   end
 
+  test "#presigned_url respects port configuration" do
+    config = ExAws.Config.new(:s3, [port: 1234])
+    {:ok, url} = S3.presigned_url(config, :get, "bucket", "foo.txt")
+    uri = URI.parse(url)
+    assert uri.port == 1234
+  end
+
   defp assert_pre_signed_url(url, expected_scheme_host_path, expected_expire) do
     uri = URI.parse(url)
     assert expected_scheme_host_path == "#{uri.scheme}://#{uri.host}#{uri.path}"


### PR DESCRIPTION
This PR fixes`S3.presigned_url/4` and friends so that they respect a port specified in the S3 config.

Fixes #363.