### PR TITLE
Do not pass negative ms to send_after in AuthCache

### DIFF
--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -65,7 +65,7 @@ defmodule ExAws.Config.AuthCache do
     expiration = expiration |> ExAws.Utils.iso_z_to_secs
     time_to_expiration = expiration - ExAws.Utils.now_in_seconds
     refresh_in = time_to_expiration - 5 * 60 # check five mins prior to expiration
-    refresh_in * 1000
+    max(0, refresh_in * 1000) # check now if we should have checked in the past
   end
 
 end


### PR DESCRIPTION
Currently, if refresh_in determines that the credentials should have already been refreshed, the auth_cache process crashes. While I believe that (functionally) the code after this change has the same effect, the error is no longer logged.